### PR TITLE
Add support for snoozing and stopping alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ There are a few services you can use on the <..>_bed_temperature entities:
   - Turns off 8 sleep side. Input entity must be a <..>_bed_temperature entity.
 - **Side On**
   - Turns on 8 sleep side in smart mode. Input entity must be a <..>_bed_temperature entity.
+- **Alarm Snooze**
+  - Snoozes an active alarm on a <..>_bed_temperature entity for a specified number of minutes.
+- **Alarm Stop**
+  - Stops an active alarm on a <..>_bed_temperature entity.
 - **Start Away Mode**
   - Turns on away mode for an 8 sleep side. Input entity must be a <..>_bed_temperature entity.
 - **Stop Away Mode**
@@ -88,7 +92,7 @@ There are a few possible sensor values for each Eight Sleep side. Some ones with
 | Breath Rate             | Side  | Measurement | Yes      |                                                                                                                                                                                                 |
 | Heart Rate              | Side  | Measurement | Yes      |                                                                                                                                                                                                 |
 | HRV                     | Side  | Measurement | Yes      |                                                                                                                                                                                                 |
-| Next Alarm              | Side  | Datetime    | Yes      |                                                                                                                                                                                                 |
+| Next Alarm              | Side  | Datetime    | Yes      | The alarm ID is available as an attribute on the sensor.                                                                                                                                        |
 | Previous Presence End   | Side  | Datetime    | Yes      | Unfortunately can't be used for Bed Presence because this doesn't update until after the sleep session is over.                                                                                 |
 | Previous Presence Start | Side  | Datetime    | Yes      | Unfortunately can't be used for Bed Presence because this doesn't update until after the sleep session is over.                                                                                 |
 | Sleep Fitness Score     | Side  | Measurement | Yes      |                                                                                                                                                                                                 |

--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -264,6 +264,14 @@ class EightSleepBaseEntity(CoordinatorEntity[DataUpdateCoordinator]):
         """Handle eight sleep side on calls."""
         await self._generic_service_call(self._user_obj.turn_on_side)
 
+    async def async_alarm_snooze(self, duration: int) -> None:
+        """Handle eight sleep alarm snooze calls."""
+        await self._generic_service_call(lambda: self._user_obj.alarm_snooze(duration))
+
+    async def async_alarm_stop(self) -> None:
+        """Handle eight sleep alarm stop calls."""
+        await self._generic_service_call(self._user_obj.alarm_stop)
+
     async def async_start_away_mode(
         self,
     ) -> None:

--- a/custom_components/eight_sleep/const.py
+++ b/custom_components/eight_sleep/const.py
@@ -50,6 +50,8 @@ SERVICE_HEAT_SET = "heat_set"
 SERVICE_HEAT_INCREMENT = "heat_increment"
 SERVICE_SIDE_OFF = "side_off"
 SERVICE_SIDE_ON = "side_on"
+SERVICE_ALARM_SNOOZE = "alarm_snooze"
+SERVICE_ALARM_STOP = "alarm_stop"
 SERVICE_AWAY_MODE_START = "away_mode_start"
 SERVICE_AWAY_MODE_STOP = "away_mode_stop"
 

--- a/custom_components/eight_sleep/services.yaml
+++ b/custom_components/eight_sleep/services.yaml
@@ -56,6 +56,24 @@ side_on:
     entity:
       integration: eight_sleep
       domain: sensor
+alarm_snooze:
+  target:
+    entity:
+      integration: eight_sleep
+      domain: sensor
+  fields:
+    duration:
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 1440
+          unit_of_measurement: minutes
+alarm_stop:
+  target:
+    entity:
+      integration: eight_sleep
+      domain: sensor
 away_mode_start:
   target:
     entity:

--- a/custom_components/eight_sleep/translations/en.json
+++ b/custom_components/eight_sleep/translations/en.json
@@ -56,6 +56,20 @@
             "description": "Turns on 8 sleep side in smart mode.",
             "name": "Side On"
         },
+        "alarm_snooze": {
+            "description": "Snooze alarm for the 8 sleep side.",
+            "fields": {
+                "duration": {
+                    "description": "Number of minutes to snooze alarm.",
+                    "name": "Duration"
+                }
+            },
+            "name": "Alarm Snooze"
+        },
+        "alarm_stop": {
+            "description": "Stops alarm for the 8 sleep side.",
+            "name": "Alarm Stop"
+        },
         "away_mode_start": {
             "description": "Turns on away mode for the 8 sleep side.",
             "name": "Start Away Mode"


### PR DESCRIPTION
This adds the alarm ID as an attribute of the `next_alarm` sensor, and adds two services, one to snooze, and one to stop the alarm.
