### PR TITLE
Remove side from unique_id

### DIFF
--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -72,7 +72,7 @@ def _get_device_unique_id(eight: EightSleep, user_obj: EightUser | None = None) 
     unique_id = eight.device_id
     assert unique_id
     if user_obj:
-        unique_id = f"{unique_id}.{user_obj.user_id}.{user_obj.side}"
+        unique_id = f"{unique_id}.{user_obj.user_id}"
     return unique_id
 
 


### PR DESCRIPTION
unique_id should not be based on bed side
* Leads to duplicate entities being created in HASS when a user's side changes, e.g., when a user switches to 'away' mode
* This breaks automations, since most everything relies on bed_temperature_entity

Example
The integration is set up when the bed sides are as follows: userA: left
userB: right

There will be 3 entities
1. the eight sleep device
2. userA
3. userB

If userB is set to away, the bed sides will be:
userA: both
userB: away

If HASS is restarted, there will now be a 4th entity:
4. userA_2

Impact:
The active entity will now be userA_2, and any automations that rely on userA's original entity will break

Warning:
Changing this will cause duplicate entities the first time people update. This seems reasonable, since current troubleshooting advice seems to be to reinstall the integration. Reinstallation will remove the duplicates.

Fixes lukas-clarke/eight_sleep#43