### PR TITLE
Add support for the Base

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ There are a few possible sensor values for each Eight Sleep side. Some ones with
 
 Sensor values are updated every 5 minutes
 
-When the Base is installed then the following sensors are available for each bed side:
+When the Base is installed, the following entities are available:
 
 | Entity | Type | Notes |
 |---|---|---|
@@ -118,8 +118,6 @@ When the Base is installed then the following sensors are available for each bed
 | Base Preset | String | The app currently offers three presets for the base: sleeping, relaxing, and reading. |
 
 These values are updated every minute.
-Note that the Eight Sleep API provides them independently for each side, but in reality the two sides move at the same time.
-Perhaps this is something they will change in the future?
 
 ## TODO ##
 - Translate "Heat Set" and "Heat Increment" values to temperature values in degrees for easier use.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ When the Base is installed, the following entities are available:
 | Snore Mitigation | Boolean | Indicates that the snore mitigation is active, raising the head |
 | Feet Angle | Number | Can be changed from the UI |
 | Head Angle | Number | Can be changed from the UI |
-| Base Preset | String | The app currently offers three presets for the base: sleeping, relaxing, and reading. |
+| Base Preset | Select | The app currently offers three presets for the base: sleep, relaxing, and reading. |
 
 These values are updated every minute.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,21 @@ There are a few possible sensor values for each Eight Sleep side. Some ones with
 | Sleep Stage             | Side  | String      | **No**   |                                                                                                                                                                                                 |
 | Time Slept              | Side  | Duration    | Yes      |                                                                                                                                                                                                 |
 | Side                    | Side  | String      | Yes      | The current side that this user side is set to                                                                                                                                                  |
+
 Sensor values are updated every 5 minutes
+
+When the Base is installed then the following sensors are available for each bed side:
+
+| Entity | Type | Notes |
+|---|---|---|
+| Snore Mitigation | Boolean | Indicates that the snore mitigation is active, raising the head |
+| Feet Angle | Number | Can be changed from the UI |
+| Head Angle | Number | Can be changed from the UI |
+| Base Preset | String | The app currently offers three presets for the base: sleeping, relaxing, and reading. |
+
+These values are updated every minute.
+Note that the Eight Sleep API provides them independently for each side, but in reality the two sides move at the same time.
+Perhaps this is something they will change in the future?
 
 ## TODO ##
 - Translate "Heat Set" and "Heat Increment" values to temperature values in degrees for easier use.

--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -28,8 +28,9 @@ from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.httpx_client import get_async_client
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.device_registry import DeviceInfo, async_get
+from homeassistant.helpers.device_registry import async_get
 from homeassistant.helpers.typing import UNDEFINED, ConfigType
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,

--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -42,7 +42,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.NUMBER]
 
-HEAT_SCAN_INTERVAL = timedelta(seconds=60)
+DEVICE_SCAN_INTERVAL = timedelta(seconds=60)
 USER_SCAN_INTERVAL = timedelta(seconds=300)
 BASE_SCAN_INTERVAL = timedelta(seconds=60)
 
@@ -66,7 +66,7 @@ class EightSleepConfigEntryData:
     """Data used for all entities for a given config entry."""
 
     api: EightSleep
-    heat_coordinator: DataUpdateCoordinator
+    device_coordinator: DataUpdateCoordinator
     user_coordinator: DataUpdateCoordinator
     base_coordinator: DataUpdateCoordinator
 
@@ -125,11 +125,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Authentication failed, cannot continue
         return False
 
-    heat_coordinator: DataUpdateCoordinator = DataUpdateCoordinator(
+    device_coordinator: DataUpdateCoordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
-        name=f"{DOMAIN}_heat",
-        update_interval=HEAT_SCAN_INTERVAL,
+        name=f"{DOMAIN}_device",
+        update_interval=DEVICE_SCAN_INTERVAL,
         update_method=eight.update_device_data,
     )
     user_coordinator: DataUpdateCoordinator = DataUpdateCoordinator(
@@ -146,7 +146,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_interval=BASE_SCAN_INTERVAL,
         update_method=eight.update_base_data,
     )
-    await heat_coordinator.async_config_entry_first_refresh()
+    await device_coordinator.async_config_entry_first_refresh()
     await user_coordinator.async_config_entry_first_refresh()
     await base_coordinator.async_config_entry_first_refresh()
 
@@ -190,7 +190,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = EightSleepConfigEntryData(
-        eight, heat_coordinator, user_coordinator, base_coordinator
+        eight, device_coordinator, user_coordinator, base_coordinator
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -251,7 +251,7 @@ class EightSleepBaseEntity(CoordinatorEntity[DataUpdateCoordinator]):
         config_entry_data: EightSleepConfigEntryData = self.hass.data[DOMAIN][
             self._config_entry.entry_id
         ]
-        await config_entry_data.heat_coordinator.async_request_refresh()
+        await config_entry_data.device_coordinator.async_request_refresh()
 
     async def async_heat_set(
         self, target: int, duration: int, sleep_stage: str

--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -162,11 +162,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         user_device_data = device_data.copy()
         base_hardware_info = user.base_data.get("hardwareInfo", {})
         if 'sku' in base_hardware_info:
-            user_device_data[ATTR_MODEL] += f", Base ({base_hardware_info['sku']})"
+            user_device_data[ATTR_MODEL] += f", Base {base_hardware_info['sku']}"
         if 'hardwareVersion' in base_hardware_info:
-            user_device_data[ATTR_HW_VERSION] += f", Base ({base_hardware_info['hardwareVersion']})"
+            user_device_data[ATTR_HW_VERSION] += f", Base {base_hardware_info['hardwareVersion']}"
         if 'softwareVersion' in base_hardware_info:
-            user_device_data[ATTR_SW_VERSION] += f", Base ({base_hardware_info['softwareVersion']})"
+            user_device_data[ATTR_SW_VERSION] += f", Base {base_hardware_info['softwareVersion']}"
 
         dev_reg.async_get_or_create(
             config_entry_id=entry.entry_id,

--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.httpx_client import get_async_client
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo, async_get
 from homeassistant.helpers.typing import UNDEFINED, ConfigType
@@ -110,6 +111,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         client_id,
         client_secret,
         client_session=async_get_clientsession(hass),
+        httpx_client=get_async_client(hass)
     )
     # Authenticate, build sensors
     try:

--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -232,6 +232,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class EightSleepBaseEntity(CoordinatorEntity[DataUpdateCoordinator]):
     """The base Eight Sleep entity class."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         entry: ConfigEntry,
@@ -248,16 +250,7 @@ class EightSleepBaseEntity(CoordinatorEntity[DataUpdateCoordinator]):
         self._sensor = sensor
         self._user_obj = user
 
-        mapped_name = str(NAME_MAP.get(sensor, sensor.replace("_", " ").title()))
-
-        if base_entity:
-            self._attr_name = f"Eight Sleep Base {mapped_name}"
-        elif self._user_obj is not None:
-            assert self._user_obj.user_profile
-            name = f"{self._user_obj.user_profile['firstName']}'s {mapped_name}"
-            self._attr_name = name
-        else:
-            self._attr_name = f"Eight Sleep {mapped_name}"
+        self._attr_name = str(NAME_MAP.get(sensor, sensor.replace("_", " ").title()))
 
         device_id = _get_device_unique_id(eight, self._user_obj, base_entity)
         self._attr_unique_id = f"{device_id}.{sensor}"

--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -206,18 +206,15 @@ class EightSleepBaseEntity(CoordinatorEntity[DataUpdateCoordinator]):
         entry: ConfigEntry,
         coordinator: DataUpdateCoordinator,
         eight: EightSleep,
-        user_id: str | None,
+        user: EightUser | None,
         sensor: str,
     ) -> None:
         """Initialize the data object."""
         super().__init__(coordinator)
         self._config_entry = entry
         self._eight = eight
-        self._user_id = user_id
         self._sensor = sensor
-        self._user_obj: EightUser | None = None
-        if user_id:
-            self._user_obj = self._eight.users[user_id]
+        self._user_obj = user
 
         mapped_name = str(NAME_MAP.get(sensor, sensor.replace("_", " ").title()))
 

--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -40,7 +40,7 @@ from .const import DOMAIN, NAME_MAP
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.NUMBER]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.NUMBER, Platform.SELECT]
 
 DEVICE_SCAN_INTERVAL = timedelta(seconds=60)
 USER_SCAN_INTERVAL = timedelta(seconds=300)

--- a/custom_components/eight_sleep/binary_sensor.py
+++ b/custom_components/eight_sleep/binary_sensor.py
@@ -1,5 +1,6 @@
 """Support for Eight Sleep binary sensors."""
 from __future__ import annotations
+from typing import Callable
 
 from custom_components.eight_sleep.pyEight.user import EightUser
 
@@ -72,7 +73,7 @@ class EightBinaryEntity(EightSleepBaseEntity, BinarySensorEntity):
         eight: EightSleep,
         user: EightUser | None,
         entity_description: BinarySensorEntityDescription,
-        value_getter: callable
+        value_getter: Callable[[], bool | None]
     ) -> None:
         super().__init__(entry, coordinator, eight, user, entity_description.key)
         self.entity_description = entity_description

--- a/custom_components/eight_sleep/binary_sensor.py
+++ b/custom_components/eight_sleep/binary_sensor.py
@@ -22,12 +22,14 @@ from .const import DOMAIN
 BED_PRESENCE_DESCRIPTION = BinarySensorEntityDescription(
     key="bed_presence",
     name="Bed Presence",
+    has_entity_name=True,
     device_class=BinarySensorDeviceClass.OCCUPANCY,
 )
 
 SNORE_MITIGATION_DESCRIPTION = BinarySensorEntityDescription(
     key="snore_mitigation",
     name="Snore Mitigaton",
+    has_entity_name=True,
     icon="mdi:account-alert",
     device_class=BinarySensorDeviceClass.RUNNING,
 )

--- a/custom_components/eight_sleep/binary_sensor.py
+++ b/custom_components/eight_sleep/binary_sensor.py
@@ -8,6 +8,7 @@ from .pyEight.eight import EightSleep
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
+    BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -17,8 +18,15 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from . import EightSleepBaseEntity, EightSleepConfigEntryData
 from .const import DOMAIN
 
+SNORE_MITIGATION_DESCRIPTION = BinarySensorEntityDescription(
+    key="snore_mitigation",
+    name="Snore Mitigaton",
+    translation_key="snore_mitigation",
+    icon="mdi:account-alert",
+    device_class=BinarySensorDeviceClass.RUNNING,
+)
+
 _LOGGER = logging.getLogger(__name__)
-BINARY_SENSORS = ["bed_presence"]
 
 
 async def async_setup_entry(
@@ -28,11 +36,16 @@ async def async_setup_entry(
     config_entry_data: EightSleepConfigEntryData = hass.data[DOMAIN][entry.entry_id]
     eight = config_entry_data.api
     heat_coordinator = config_entry_data.heat_coordinator
-    async_add_entities(
-        EightHeatSensor(entry, heat_coordinator, eight, user.user_id, binary_sensor)
-        for user in eight.users.values()
-        for binary_sensor in BINARY_SENSORS
-    )
+
+    entities: list[BinarySensorEntity] = []
+
+    for user in eight.users.values():
+        entities.append(EightHeatSensor(entry, heat_coordinator, eight, user.user_id))
+
+        if eight.has_base:
+            entities.append(EightBinaryEntity(SNORE_MITIGATION_DESCRIPTION, lambda: user.in_snore_mitigation))
+
+    async_add_entities(entities)
 
 
 class EightHeatSensor(EightSleepBaseEntity, BinarySensorEntity):
@@ -45,17 +58,13 @@ class EightHeatSensor(EightSleepBaseEntity, BinarySensorEntity):
         entry: ConfigEntry,
         coordinator: DataUpdateCoordinator,
         eight: EightSleep,
-        user_id: str | None,
-        sensor: str,
+        user_id: str | None
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(entry, coordinator, eight, user_id, sensor)
+        super().__init__(entry, coordinator, eight, user_id, "bed_presence")
         assert self._user_obj
         _LOGGER.debug(
-            "Presence Sensor: %s, Side: %s, User: %s",
-            sensor,
-            self._user_obj.side,
-            user_id,
+            f"Presence Sensor, Side: {self._user_obj.side}, User: {user_id}"
         )
 
     @property
@@ -63,3 +72,17 @@ class EightHeatSensor(EightSleepBaseEntity, BinarySensorEntity):
         """Return true if the binary sensor is on."""
         assert self._user_obj
         return bool(self._user_obj.bed_presence)
+
+
+class EightBinaryEntity(BinarySensorEntity):
+    def __init__(
+        self,
+        entity_description: BinarySensorEntityDescription,
+        value_getter: callable
+    ) -> None:
+        self.entity_description = entity_description
+        self._value_getter = value_getter
+
+    @property
+    def is_on(self) -> bool | None:
+        return self._value_getter()

--- a/custom_components/eight_sleep/binary_sensor.py
+++ b/custom_components/eight_sleep/binary_sensor.py
@@ -54,7 +54,7 @@ async def async_setup_entry(
         if eight.has_base:
             entities.append(EightBinaryEntity(
                 entry,
-                config_entry_data.user_coordinator,
+                config_entry_data.base_coordinator,
                 eight,
                 user,
                 SNORE_MITIGATION_DESCRIPTION,

--- a/custom_components/eight_sleep/binary_sensor.py
+++ b/custom_components/eight_sleep/binary_sensor.py
@@ -45,7 +45,7 @@ async def async_setup_entry(
     for user in eight.users.values():
         entities.append(EightBinaryEntity(
             entry,
-            config_entry_data.heat_coordinator,
+            config_entry_data.device_coordinator,
             eight,
             user,
             BED_PRESENCE_DESCRIPTION,

--- a/custom_components/eight_sleep/binary_sensor.py
+++ b/custom_components/eight_sleep/binary_sensor.py
@@ -51,14 +51,15 @@ async def async_setup_entry(
             BED_PRESENCE_DESCRIPTION,
             lambda: user.bed_presence))
 
-        if eight.has_base:
-            entities.append(EightBinaryEntity(
-                entry,
-                config_entry_data.base_coordinator,
-                eight,
-                user,
-                SNORE_MITIGATION_DESCRIPTION,
-                lambda: user.in_snore_mitigation))
+    if eight.base_user:
+        entities.append(EightBinaryEntity(
+            entry,
+            config_entry_data.base_coordinator,
+            eight,
+            None,
+            SNORE_MITIGATION_DESCRIPTION,
+            lambda: eight.base_user.in_snore_mitigation,
+            base_entity=True))
 
     async_add_entities(entities)
 
@@ -73,9 +74,10 @@ class EightBinaryEntity(EightSleepBaseEntity, BinarySensorEntity):
         eight: EightSleep,
         user: EightUser | None,
         entity_description: BinarySensorEntityDescription,
-        value_getter: Callable[[], bool | None]
+        value_getter: Callable[[], bool | None],
+        base_entity: bool = False
     ) -> None:
-        super().__init__(entry, coordinator, eight, user, entity_description.key)
+        super().__init__(entry, coordinator, eight, user, entity_description.key, base_entity)
         self.entity_description = entity_description
         self._value_getter = value_getter
 

--- a/custom_components/eight_sleep/binary_sensor.py
+++ b/custom_components/eight_sleep/binary_sensor.py
@@ -22,14 +22,12 @@ from .const import DOMAIN
 BED_PRESENCE_DESCRIPTION = BinarySensorEntityDescription(
     key="bed_presence",
     name="Bed Presence",
-    has_entity_name=True,
     device_class=BinarySensorDeviceClass.OCCUPANCY,
 )
 
 SNORE_MITIGATION_DESCRIPTION = BinarySensorEntityDescription(
     key="snore_mitigation",
     name="Snore Mitigaton",
-    has_entity_name=True,
     icon="mdi:account-alert",
     device_class=BinarySensorDeviceClass.RUNNING,
 )

--- a/custom_components/eight_sleep/config_flow.py
+++ b/custom_components/eight_sleep/config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
 )
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.selector import (
     TextSelector,
     TextSelectorConfig,
@@ -69,6 +70,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             client_id,
             client_secret,
             client_session=async_get_clientsession(self.hass),
+            httpx_client=get_async_client(self.hass),
         )
 
         try:

--- a/custom_components/eight_sleep/const.py
+++ b/custom_components/eight_sleep/const.py
@@ -36,9 +36,18 @@ NAME_MAP = {
     ),
     "presence_start": NameMapEntity(
         "Previous Presence Start",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        state_class=None
     ),
     "presence_end": NameMapEntity(
         "Previous Presence End",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        state_class=None
+    ),
+    "next_alarm": NameMapEntity(
+        "Next Alarm",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        state_class=None
     ),
 }
 

--- a/custom_components/eight_sleep/const.py
+++ b/custom_components/eight_sleep/const.py
@@ -1,4 +1,4 @@
-from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 
 """Eight Sleep constants."""
 DOMAIN = "eight_sleep"
@@ -9,12 +9,16 @@ USER_ENTITY = "user"
 
 class NameMapEntity:
     def __init__(
-        self, name, measurement=None, state_class=None, device_class=None
+        self,
+        name: str,
+        measurement: str = None,
+        device_class: SensorDeviceClass = None,
+        state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     ) -> None:
         self.name = name
         self.measurement = measurement
-        self.state_class = state_class
         self.device_class = device_class
+        self.state_class = state_class
 
     def __str__(self) -> str:
         return self.name
@@ -28,7 +32,7 @@ NAME_MAP = {
     "current_hrv": NameMapEntity("HRV", "ms"),
     "current_breath_rate": NameMapEntity("Breath Rate", "/min"),
     "time_slept": NameMapEntity(
-        "Time Slept", "s", SensorDeviceClass.DURATION, SensorDeviceClass.DURATION
+        "Time Slept", "s", SensorDeviceClass.DURATION
     ),
     "presence_start": NameMapEntity(
         "Previous Presence Start",

--- a/custom_components/eight_sleep/const.py
+++ b/custom_components/eight_sleep/const.py
@@ -3,9 +3,6 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 """Eight Sleep constants."""
 DOMAIN = "eight_sleep"
 
-HEAT_ENTITY = "heat"
-USER_ENTITY = "user"
-
 
 class NameMapEntity:
     def __init__(

--- a/custom_components/eight_sleep/const.py
+++ b/custom_components/eight_sleep/const.py
@@ -1,8 +1,4 @@
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorEntity,
-    SensorStateClass,
-)
+from homeassistant.components.sensor import SensorDeviceClass
 
 """Eight Sleep constants."""
 DOMAIN = "eight_sleep"

--- a/custom_components/eight_sleep/const.py
+++ b/custom_components/eight_sleep/const.py
@@ -11,9 +11,9 @@ class NameMapEntity:
     def __init__(
         self,
         name: str,
-        measurement: str = None,
-        device_class: SensorDeviceClass = None,
-        state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+        measurement: str | None = None,
+        device_class: SensorDeviceClass | None = None,
+        state_class: SensorStateClass | None = SensorStateClass.MEASUREMENT
     ) -> None:
         self.name = name
         self.measurement = measurement

--- a/custom_components/eight_sleep/number.py
+++ b/custom_components/eight_sleep/number.py
@@ -1,3 +1,4 @@
+from typing import Callable
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
@@ -40,16 +41,16 @@ async def async_setup_entry(
     if eight.has_base:
         for user in eight.users.values():
             def set_leg_angle(value):
-                entry.async_create_task(user.set_base_angle(leg_angle=value, torso_angle=user.torso_angle))
+                entry.async_create_task(hass, user.set_base_angle(leg_angle=value, torso_angle=user.torso_angle))
 
             def set_torso_angle(value):
-                entry.async_create_task(user.set_base_angle(leg_angle=user.leg_angle, torso_angle=value))
+                entry.async_create_task(hass, user.set_base_angle(leg_angle=user.leg_angle, torso_angle=value))
 
             # Note: The API refers to these as "leg" and "torso" angles, but the app shows them as "feet" and "head"
             # angles. This is the point where we change the terminology to match the app.
             entities.extend([
                 EightNumberEntity(
-                    config_entry_data,
+                    entry,
                     coordinator,
                     eight,
                     user,
@@ -57,7 +58,7 @@ async def async_setup_entry(
                     lambda: user.leg_angle,
                     set_leg_angle),
                 EightNumberEntity(
-                    config_entry_data,
+                    entry,
                     coordinator,
                     eight,
                     user,
@@ -72,13 +73,13 @@ class EightNumberEntity(EightSleepBaseEntity, NumberEntity):
 
     def __init__(
         self,
-        entry: EightSleepConfigEntryData,
+        entry: ConfigEntry,
         coordinator: DataUpdateCoordinator,
         eight: EightSleep,
         user: EightUser | None,
         entity_description: NumberEntityDescription,
-        value_getter: callable,
-        set_value_callback: callable
+        value_getter: Callable[[], float | None],
+        set_value_callback: Callable[[float], None]
     ):
         super().__init__(entry, coordinator, eight, user, entity_description.key)
         self.entity_description = entity_description

--- a/custom_components/eight_sleep/number.py
+++ b/custom_components/eight_sleep/number.py
@@ -38,33 +38,33 @@ async def async_setup_entry(
 
     entities: list[NumberEntity] = []
 
-    if eight.has_base:
-        for user in eight.users.values():
-            def set_leg_angle(value):
-                entry.async_create_task(hass, user.set_base_angle(leg_angle=value, torso_angle=user.torso_angle))
+    user = eight.base_user
+    if user:
+        def set_leg_angle(value):
+            entry.async_create_task(hass, user.set_base_angle(leg_angle=value, torso_angle=user.torso_angle))
 
-            def set_torso_angle(value):
-                entry.async_create_task(hass, user.set_base_angle(leg_angle=user.leg_angle, torso_angle=value))
+        def set_torso_angle(value):
+            entry.async_create_task(hass, user.set_base_angle(leg_angle=user.leg_angle, torso_angle=value))
 
-            # Note: The API refers to these as "leg" and "torso" angles, but the app shows them as "feet" and "head"
-            # angles. This is the point where we change the terminology to match the app.
-            entities.extend([
-                EightNumberEntity(
-                    entry,
-                    coordinator,
-                    eight,
-                    user,
-                    FEET_DESCRIPTION,
-                    lambda: user.leg_angle,
-                    set_leg_angle),
-                EightNumberEntity(
-                    entry,
-                    coordinator,
-                    eight,
-                    user,
-                    HEAD_DESCRIPTION,
-                    lambda: user.torso_angle,
-                    set_torso_angle)])
+        # Note: The API refers to these as "leg" and "torso" angles, but the app shows them as "feet" and "head" angles.
+        # This is the point where we change the terminology to match the app.
+        entities.extend([
+            EightNumberEntity(
+                entry,
+                coordinator,
+                eight,
+                user,
+                FEET_DESCRIPTION,
+                lambda: user.leg_angle,
+                set_leg_angle),
+            EightNumberEntity(
+                entry,
+                coordinator,
+                eight,
+                user,
+                HEAD_DESCRIPTION,
+                lambda: user.torso_angle,
+                set_torso_angle)])
 
     async_add_entities(entities)
 
@@ -81,7 +81,7 @@ class EightNumberEntity(EightSleepBaseEntity, NumberEntity):
         value_getter: Callable[[], float | None],
         set_value_callback: Callable[[float], None]
     ):
-        super().__init__(entry, coordinator, eight, user, entity_description.key)
+        super().__init__(entry, coordinator, eight, user, entity_description.key, base_entity=True)
         self.entity_description = entity_description
         self._value_getter = value_getter
         self._set_value_callback = set_value_callback

--- a/custom_components/eight_sleep/number.py
+++ b/custom_components/eight_sleep/number.py
@@ -17,7 +17,6 @@ FEET_DESCRIPTION = NumberEntityDescription(
     native_min_value=0,
     native_step=1,
     name="Feet Angle",
-    has_entity_name=True,
     icon="mdi:foot-print",
 )
 
@@ -28,7 +27,6 @@ HEAD_DESCRIPTION = NumberEntityDescription(
     native_min_value=0,
     native_step=1,
     name="Head Angle",
-    has_entity_name=True,
     icon="mdi:head",
 )
 

--- a/custom_components/eight_sleep/number.py
+++ b/custom_components/eight_sleep/number.py
@@ -17,6 +17,8 @@ FEET_DESCRIPTION = NumberEntityDescription(
     native_min_value=0,
     native_step=1,
     name="Feet Angle",
+    has_entity_name=True,
+    icon="mdi:foot-print",
 )
 
 HEAD_DESCRIPTION = NumberEntityDescription(
@@ -26,6 +28,8 @@ HEAD_DESCRIPTION = NumberEntityDescription(
     native_min_value=0,
     native_step=1,
     name="Head Angle",
+    has_entity_name=True,
+    icon="mdi:head",
 )
 
 

--- a/custom_components/eight_sleep/number.py
+++ b/custom_components/eight_sleep/number.py
@@ -1,0 +1,73 @@
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from custom_components.eight_sleep import EightSleepConfigEntryData
+from custom_components.eight_sleep.const import DOMAIN
+
+FEET_DESCRIPTION = NumberEntityDescription(
+    key="feet_angle",
+    native_unit_of_measurement="°",
+    native_max_value=20,
+    native_min_value=0,
+    native_step=1,
+    translation_key="feet_angle",
+    name="Feet Angle",
+)
+
+HEAD_DESCRIPTION = NumberEntityDescription(
+    key="head_angle",
+    native_unit_of_measurement="°",
+    native_max_value=45,
+    native_min_value=0,
+    native_step=1,
+    translation_key="head_angle",
+    name="Head Angle",
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    config_entry_data: EightSleepConfigEntryData = hass.data[DOMAIN][entry.entry_id]
+    eight = config_entry_data.api
+
+    entities: list[NumberEntity] = []
+
+    if eight.has_base:
+        for user in eight.users.values():
+            def set_leg_angle(value):
+                entry.async_create_task(user.set_base_angle(leg_angle=value, torso_angle=user.torso_angle))
+
+            def set_torso_angle(value):
+                entry.async_create_task(user.set_base_angle(leg_angle=user.leg_angle, torso_angle=value))
+
+            # Note: The API refers to these as "leg" and "torso" angles, but the app shows them as "feet" and "head"
+            # angles. This is the point where we change the terminology to match the app.
+            entities.extend([
+                EightNumberEntity(FEET_DESCRIPTION, lambda: user.leg_angle, set_leg_angle),
+                EightNumberEntity(HEAD_DESCRIPTION, lambda: user.torso_angle, set_torso_angle)])
+
+    async_add_entities(entities)
+
+
+class EightNumberEntity(NumberEntity):
+
+    def __init__(
+        self,
+        entity_description: NumberEntityDescription,
+        value_getter: callable,
+        set_value_callback: callable
+    ):
+        self.entity_description = entity_description
+        self._value_getter = value_getter
+        self._set_value_callback = set_value_callback
+
+    @property
+    def native_value(self) -> float | None:
+        return self._value_getter()
+
+    async def async_set_native_value(self, value: float) -> None:
+        self._set_value_callback(value)
+        self.schedule_update_ha_state()

--- a/custom_components/eight_sleep/number.py
+++ b/custom_components/eight_sleep/number.py
@@ -34,7 +34,7 @@ async def async_setup_entry(
 ) -> None:
     config_entry_data: EightSleepConfigEntryData = hass.data[DOMAIN][entry.entry_id]
     eight = config_entry_data.api
-    coordinator = config_entry_data.user_coordinator
+    coordinator = config_entry_data.base_coordinator
 
     entities: list[NumberEntity] = []
 

--- a/custom_components/eight_sleep/pyEight/constants.py
+++ b/custom_components/eight_sleep/pyEight/constants.py
@@ -40,7 +40,7 @@ DEFAULT_API_HEADERS = {
     "accept-encoding": "gzip",
     "accept": "application/json",
     "host": "app-api.8slp.net",
-    "authorization": f"Bearer ADD",
+    "authorization": "Bearer ADD",
 }
 
 DEFAULT_AUTH_HEADERS = {

--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -49,8 +49,8 @@ class EightSleep:
         email: str,
         password: str,
         timezone: str,
-        client_id: str = None,
-        client_secret: str = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
         client_session: ClientSession | None = None,
         httpx_client: httpx.AsyncClient | None = None,
         check_auth: bool = False,
@@ -73,7 +73,7 @@ class EightSleep:
         self.users: dict[str, EightUser] = {}
 
         self._user_id: str | None = None
-        self._token: str | None = None
+        self._token: Token | None = None
         self._token_expiration: datetime | None = None
         self._device_ids: list[str] = []
         self._is_pod: bool = False

--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -98,11 +98,6 @@ class EightSleep:
             asyncio.run(self.stop())
 
     @property
-    def token(self) -> str | None:
-        """Return session token."""
-        return self._token
-
-    @property
     def user_id(self) -> str | None:
         """Return user ID of the logged in user."""
         return self._user_id

--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -20,8 +20,19 @@ import time
 import httpx
 from aiohttp.client import ClientError, ClientSession, ClientTimeout
 
-from .constants import *
-from .exceptions import NotAuthenticatedError, RequestError
+from .constants import (
+    DEFAULT_TIMEOUT,
+    KNOWN_CLIENT_ID,
+    KNOWN_CLIENT_SECRET,
+    AUTH_URL,
+    DEFAULT_AUTH_HEADERS,
+    CLIENT_API_URL,
+    DEFAULT_API_HEADERS,
+    TOKEN_TIME_BUFFER_SECONDS,
+    RAW_TO_CELSIUS_MAP,
+    RAW_TO_FAHRENHEIT_MAP,
+)
+from .exceptions import RequestError
 from .user import EightUser
 from .structs import Token
 

--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -246,8 +246,14 @@ class EightSleep:
 
     async def update_user_data(self) -> None:
         """Update data for users."""
-        for obj in self.users.values():
-            await obj.update_user()
+        for user in self.users.values():
+            await user.update_user()
+
+    async def update_base_data(self) -> None:
+        """Update data for the bed base."""
+        if self.has_base:
+            for user in self.users.values():
+                await user.update_base_data()
 
     async def start(self) -> bool:
         """Start api initialization."""

--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -76,6 +76,7 @@ class EightSleep:
         self._token_expiration: datetime | None = None
         self._device_ids: list[str] = []
         self._is_pod: bool = False
+        self._has_base: bool = False
 
         # Setup 10 element list
         self._device_json_list: list[dict] = []
@@ -135,8 +136,13 @@ class EightSleep:
 
     @property
     def is_pod(self) -> bool:
-        """Return if device is a POD."""
+        """Return if device is a Pod."""
         return self._is_pod
+
+    @property
+    def has_base(self) -> bool:
+        """Return if device has a base."""
+        return self._has_base
 
     def convert_raw_bed_temp_to_degrees(self, raw_value, degree_unit):
         """degree_unit can be 'c' or 'f'
@@ -271,7 +277,10 @@ class EightSleep:
         if "cooling" in dlist["user"]["features"]:
             self._is_pod = True
 
-        _LOGGER.debug("Devices: %s, POD: %s", self._device_ids, self._is_pod)
+        if "elevation" in dlist["user"]["features"]:
+            self._has_base = True
+
+        _LOGGER.debug(f"Devices: {self._device_ids}, Pod: {self._is_pod}, Base: {self._has_base}")
 
     async def assign_users(self) -> None:
         """Update device properties."""

--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -250,10 +250,17 @@ class EightSleep:
             await user.update_user()
 
     async def update_base_data(self) -> None:
-        """Update data for the bed base."""
+        """Update data for the bed base.
+        While it's possible to retrieve the data for each user, the contents are identical."""
+        user = self.base_user
+        if user:
+            await user.update_base_data()
+
+    @property
+    def base_user(self) -> EightUser | None:
+        """Return the user object for the base."""
         if self.has_base:
-            for user in self.users.values():
-                await user.update_base_data()
+            return next(iter(self.users.values()))
 
     async def start(self) -> bool:
         """Start api initialization."""

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -935,3 +935,18 @@ class EightUser:  # pylint: disable=too-many-public-methods
                 "enableOfflineMode": False
             }
             await self.device.api_request("POST", url, data=payload)
+
+    async def set_base_preset(self, preset: str) -> None:
+        """Set the preset of the bed base."""
+        if self.device.has_base:
+            # Update the preset locally
+            self.base_data_for_side["preset"]["name"] = preset
+
+            url = f"{APP_API_URL}v1/users/{self.user_id}/base/angle?ignoreDeviceErrors=false"
+            payload = {
+                "deviceId": self.device.device_id,
+                "deviceOnline": True,
+                "preset": preset,
+                "enableOfflineMode": False
+            }
+            await self.device.api_request("POST", url, data=payload)

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -152,7 +152,7 @@ class EightUser:  # pylint: disable=too-many-public-methods
     @property
     def base_preset(self) -> str | None:
         """Return the base preset.
-        Currently these are sleeping, relaxing and reading."""
+        Currently these are sleep, relaxing and reading."""
         return self.base_data_for_side.get("preset", {}).get("name")
 
     @property

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -716,7 +716,6 @@ class EightUser:  # pylint: disable=too-many-public-methods
         """Update all user data."""
         self.side = await self.get_user_side()
         await self.update_intervals_data()
-        await self.update_base_data()
 
         now = datetime.today()
         start = now - timedelta(days=2)

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -145,12 +145,14 @@ class EightUser:  # pylint: disable=too-many-public-methods
 
     @property
     def base_data_for_side(self) -> dict[str, Any]:
-        """Return the base data for the user's side."""
+        """Return the base data for the user's side.
+        Currently the data is identical for both sides."""
         return self.base_data.get(self.corrected_side_for_key, {})
 
     @property
     def base_preset(self) -> str | None:
-        """Return the base preset. Currently these are sleeping, relaxing and reading."""
+        """Return the base preset.
+        Currently these are sleeping, relaxing and reading."""
         return self.base_data_for_side.get("preset", {}).get("name")
 
     @property

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -139,12 +139,12 @@ class EightUser:  # pylint: disable=too-many-public-methods
         return self._user_profile
 
     @property
-    def base_data(self) -> dict[str, Any] | None:
+    def base_data(self) -> dict[str, Any]:
         """Return the base data."""
         return self._base_data
 
     @property
-    def base_data_for_side(self) -> dict[str, Any] | None:
+    def base_data_for_side(self) -> dict[str, Any]:
         """Return the base data for the user's side."""
         return self.base_data.get(self.corrected_side_for_key, {})
 
@@ -154,12 +154,12 @@ class EightUser:  # pylint: disable=too-many-public-methods
         return self.base_data_for_side.get("preset", {}).get("name")
 
     @property
-    def leg_angle(self) -> int | None:
+    def leg_angle(self) -> int:
         """Return the base leg angle."""
         return self.base_data_for_side.get("leg", {}).get("currentAngle", 0)
 
     @property
-    def torso_angle(self) -> int | None:
+    def torso_angle(self) -> int:
         """Return the base torso angle."""
         return self.base_data_for_side.get("torso", {}).get("currentAngle", 0)
 
@@ -473,7 +473,7 @@ class EightUser:  # pylint: disable=too-many-public-methods
     @property
     def last_latency_out_score(self) -> int | None:
         """Return latency out score for previous session."""
-        return self._get_froutine_score(1, "latencyOutSeconds")
+        return self._get_routine_score(1, "latencyOutSeconds")
 
     @property
     def last_wakeup_consistency_score(self) -> int | None:
@@ -912,7 +912,7 @@ class EightUser:  # pylint: disable=too-many-public-methods
         self.next_alarm = self.device.convert_string_to_datetime(nextTimestamp)
         self.next_alarm_id = resp["state"]["nextAlarm"]["alarmId"]
 
-    async def update_base_data(self) -> dict:
+    async def update_base_data(self):
         """Update the data about the bed base."""
         if self.device.has_base:
             url = f"{APP_API_URL}v1/users/{self.user_id}/base"
@@ -929,7 +929,7 @@ class EightUser:  # pylint: disable=too-many-public-methods
                 "torsoAngle": torso_angle,
                 "enableOfflineMode": False
             }
-            await self.device.api_request("POST", url, json=payload)
+            await self.device.api_request("POST", url, data=payload)
 
             # Update the angles locally
             self.base_data_for_side["leg"]["currentAngle"] = leg_angle

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -15,8 +15,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 from zoneinfo import ZoneInfo
 import pytz
 
-from .constants import *
-from .constants import *
+from .constants import APP_API_URL, DATE_FORMAT, DATE_TIME_ISO_FORMAT, CLIENT_API_URL, POSSIBLE_SLEEP_STAGES
 
 if TYPE_CHECKING:
     from .eight import EightSleep

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -333,11 +333,6 @@ class EightUser:  # pylint: disable=too-many-public-methods
         return str(self._get_trend(0, ("sleepQualityScore", "hrv", "current")))
 
     @property
-    def current_heart_rate(self) -> int | None:
-        """Return wakeup consistency score for latest session."""
-        return str(self._get_trend(0, ("sleepRoutineScore", "heartRate", "current")))
-
-    @property
     def current_breath_rate(self) -> int | None:
         """Return wakeup consistency score for latest session."""
         return str(
@@ -800,7 +795,7 @@ class EightUser:  # pylint: disable=too-many-public-methods
         data = {
             "alarm": {"alarmId": self.next_alarm_id, "snoozeForMinutes": snooze_minutes}
         }
-        resp = await self.device.api_request("PUT", url, data=data)
+        await self.device.api_request("PUT", url, data=data)
 
     async def alarm_stop(self):
         """Stops the next user alarm"""
@@ -886,25 +881,3 @@ class EightUser:  # pylint: disable=too-many-public-methods
         self.next_alarm = self.device.convert_string_to_datetime(nextTimestamp)
         self.next_alarm_id = resp["state"]["nextAlarm"]["alarmId"]
 
-    def _convert_string_to_datetime(self, datetime_str):
-        datetime_str = str(datetime_str).strip()
-        # Convert string to datetime object.
-        try:
-            # Try to parse the first format
-            datetime_object = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%SZ")
-        except ValueError:
-            try:
-                # Try to parse the second format
-                datetime_object = datetime.strptime(
-                    datetime_str, "%Y-%m-%dT%H:%M:%S.%fZ"
-                )
-            except ValueError:
-                # Handle if neither format is matched
-                raise ValueError(f"Unsupported date string format for {datetime_str}")
-
-        # Set the timezone to UTC
-        utc_timezone = pytz.UTC
-        datetime_object_utc = datetime_object.replace(tzinfo=utc_timezone)
-        # Set the timezone to a specific timezone
-        timezone = pytz.timezone(self.device.timezone)
-        return datetime_object_utc.astimezone(timezone)

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -921,6 +921,10 @@ class EightUser:  # pylint: disable=too-many-public-methods
     async def set_base_angle(self, leg_angle: int, torso_angle: int) -> None:
         """Set the angles of the bed base."""
         if self.device.has_base:
+            # Update the angles locally
+            self.base_data_for_side["leg"]["currentAngle"] = leg_angle
+            self.base_data_for_side["torso"]["currentAngle"] = torso_angle
+
             url = f"{APP_API_URL}v1/users/{self.user_id}/base/angle?ignoreDeviceErrors=false"
             payload = {
                 "deviceId": self.device.device_id,
@@ -930,7 +934,3 @@ class EightUser:  # pylint: disable=too-many-public-methods
                 "enableOfflineMode": False
             }
             await self.device.api_request("POST", url, data=payload)
-
-            # Update the angles locally
-            self.base_data_for_side["leg"]["currentAngle"] = leg_angle
-            self.base_data_for_side["torso"]["currentAngle"] = torso_angle

--- a/custom_components/eight_sleep/select.py
+++ b/custom_components/eight_sleep/select.py
@@ -15,7 +15,6 @@ PRESETS = ["sleeping", "relaxing", "reading"]
 BASE_PRESET_DESCRIPTION = SelectEntityDescription(
     key="base_preset",
     name="Base Preset",
-    has_entity_name=True,
     icon="mdi:train-car-flatbed",
     options=PRESETS,
 )

--- a/custom_components/eight_sleep/select.py
+++ b/custom_components/eight_sleep/select.py
@@ -10,7 +10,7 @@ from custom_components.eight_sleep.const import DOMAIN
 from custom_components.eight_sleep.pyEight.eight import EightSleep
 from custom_components.eight_sleep.pyEight.user import EightUser
 
-PRESETS = ["sleeping", "relaxing", "reading"]
+PRESETS = ["sleep", "relaxing", "reading"]
 
 BASE_PRESET_DESCRIPTION = SelectEntityDescription(
     key="base_preset",

--- a/custom_components/eight_sleep/select.py
+++ b/custom_components/eight_sleep/select.py
@@ -1,0 +1,75 @@
+from typing import Callable
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from custom_components.eight_sleep import EightSleepBaseEntity, EightSleepConfigEntryData
+from custom_components.eight_sleep.const import DOMAIN
+from custom_components.eight_sleep.pyEight.eight import EightSleep
+from custom_components.eight_sleep.pyEight.user import EightUser
+
+PRESETS = ["sleeping", "relaxing", "reading"]
+
+BASE_PRESET_DESCRIPTION = SelectEntityDescription(
+    key="base_preset",
+    name="Base Preset",
+    has_entity_name=True,
+    icon="mdi:train-car-flatbed",
+    options=PRESETS,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    config_entry_data: EightSleepConfigEntryData = hass.data[DOMAIN][entry.entry_id]
+    eight = config_entry_data.api
+    coordinator = config_entry_data.base_coordinator
+
+    entities: list[SelectEntity] = []
+
+    user = eight.base_user
+    if user:
+        def set_preset(value):
+            entry.async_create_task(hass, user.set_base_preset(value))
+
+        entities.append(EightSelectEntity(
+            entry,
+            coordinator,
+            eight,
+            user,
+            BASE_PRESET_DESCRIPTION,
+            lambda: user.base_preset,
+            set_preset))
+
+    async_add_entities(entities)
+
+
+class EightSelectEntity(EightSleepBaseEntity, SelectEntity):
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: DataUpdateCoordinator,
+        eight: EightSleep,
+        user: EightUser,
+        entity_description: SelectEntityDescription,
+        value_getter: Callable[[], str | None],
+        set_value_callback: Callable[[str], None]
+    ) -> None:
+        super().__init__(entry, coordinator, eight, user, entity_description.key, base_entity=True)
+        self.entity_description = entity_description
+        self._attr_options = PRESETS
+        self._attr_name = "Bed Preset"
+        self._value_getter = value_getter
+        self._set_value_callback = set_value_callback
+
+    @property
+    def current_option(self) -> str | None:
+        return self._value_getter()
+
+    async def async_select_option(self, option: str) -> None:
+        self._set_value_callback(option)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -288,23 +288,24 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
             self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         elif self._sensor in (NAME_MAP):
             self._attr_native_unit_of_measurement = NAME_MAP[self._sensor].measurement
-            self._attr_state_class = NAME_MAP[self._sensor].device_class
-            self._attr_device_class = NAME_MAP[self._sensor].state_class
-
-        if (
-            self._sensor != "sleep_stage"
-            and self._sensor != "bed_state_type"
-            and self._sensor != "side"
-        ):
-            self._attr_state_class = SensorStateClass.MEASUREMENT
-
-        if (
+            self._attr_device_class = NAME_MAP[self._sensor].device_class
+            self._attr_state_class = NAME_MAP[self._sensor].state_class
+        elif (
             self._sensor == "next_alarm"
             or self._sensor == "presence_start"
             or self._sensor == "presence_end"
         ):
             self._attr_device_class = SensorDeviceClass.TIMESTAMP
-            self._attr_state_class = None
+        elif (
+            self._sensor == "sleep_stage"
+            or self._sensor == "bed_state_type"
+            or self._sensor == "side"
+            or self._sensor == "base_preset"
+        ):
+            # These have string values, leave the class None
+            pass
+        else:
+            self._attr_state_class = SensorStateClass.MEASUREMENT
 
         _LOGGER.debug(
             "User Sensor: %s, Side: %s, User: %s",

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from custom_components.eight_sleep.pyEight.user import EightUser
+
 from .pyEight.eight import EightSleep
 import voluptuous as vol
 
@@ -128,18 +130,18 @@ async def async_setup_entry(
 
     all_sensors: list[SensorEntity] = []
 
-    for obj in eight.users.values():
+    for user in eight.users.values():
         all_sensors.extend(
-            EightUserSensor(entry, user_coordinator, eight, obj.user_id, sensor)
+            EightUserSensor(entry, user_coordinator, eight, user, sensor)
             for sensor in EIGHT_USER_SENSORS
         )
         all_sensors.extend(
-            EightHeatSensor(entry, heat_coordinator, eight, obj.user_id, sensor)
+            EightHeatSensor(entry, heat_coordinator, eight, user, sensor)
             for sensor in EIGHT_HEAT_SENSORS
         )
 
         if eight.has_base:
-            all_sensors.append(EightUserSensor(entry, user_coordinator, eight, obj.user_id, "base_preset"))
+            all_sensors.append(EightUserSensor(entry, user_coordinator, eight, user, "base_preset"))
 
     all_sensors.extend(
         EightRoomSensor(entry, user_coordinator, eight, sensor)
@@ -219,18 +221,17 @@ class EightHeatSensor(EightSleepBaseEntity, SensorEntity):
         entry: ConfigEntry,
         coordinator: DataUpdateCoordinator,
         eight: EightSleep,
-        user_id: str,
+        user: EightUser | None,
         sensor: str,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(entry, coordinator, eight, user_id, sensor)
-        assert self._user_obj
+        super().__init__(entry, coordinator, eight, user, sensor)
 
         _LOGGER.debug(
             "Heat Sensor: %s, Side: %s, User: %s",
             self._sensor,
             self._user_obj.side,
-            self._user_id,
+            self._user_obj.user_id,
         )
 
     @property
@@ -275,11 +276,11 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
         entry: ConfigEntry,
         coordinator: DataUpdateCoordinator,
         eight: EightSleep,
-        user_id: str,
+        user: EightUser | None,
         sensor: str,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(entry, coordinator, eight, user_id, sensor)
+        super().__init__(entry, coordinator, eight, user, sensor)
         assert self._user_obj
 
         if self._sensor == "bed_temperature":
@@ -306,7 +307,7 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
             "User Sensor: %s, Side: %s, User: %s",
             self._sensor,
             self._user_obj.side,
-            self._user_id,
+            self._user_obj.user_id,
         )
 
     @property

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -291,12 +291,6 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
             self._attr_device_class = NAME_MAP[self._sensor].device_class
             self._attr_state_class = NAME_MAP[self._sensor].state_class
         elif (
-            self._sensor == "next_alarm"
-            or self._sensor == "presence_start"
-            or self._sensor == "presence_end"
-        ):
-            self._attr_device_class = SensorDeviceClass.TIMESTAMP
-        elif (
             self._sensor == "sleep_stage"
             or self._sensor == "bed_state_type"
             or self._sensor == "side"
@@ -322,8 +316,6 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
 
         if self._sensor in NAME_MAP:
             return getattr(self._user_obj, self._sensor)
-        if "next_alarm" in self._sensor:
-            return self._user_obj.next_alarm
         if "bed_state_type" in self._sensor:
             return self._user_obj.bed_state_type
         if "last" in self._sensor:

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -127,6 +127,7 @@ async def async_setup_entry(
     eight = config_entry_data.api
     heat_coordinator = config_entry_data.heat_coordinator
     user_coordinator = config_entry_data.user_coordinator
+    base_coordinator = config_entry_data.base_coordinator
 
     all_sensors: list[SensorEntity] = []
 
@@ -141,7 +142,7 @@ async def async_setup_entry(
         )
 
         if eight.has_base:
-            all_sensors.append(EightUserSensor(entry, user_coordinator, eight, user, "base_preset"))
+            all_sensors.append(EightUserSensor(entry, base_coordinator, eight, user, "base_preset"))
 
     all_sensors.extend(
         EightRoomSensor(entry, user_coordinator, eight, sensor)

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -125,7 +125,7 @@ async def async_setup_entry(
     """Set up the eight sleep sensors."""
     config_entry_data: EightSleepConfigEntryData = hass.data[DOMAIN][entry.entry_id]
     eight = config_entry_data.api
-    heat_coordinator = config_entry_data.heat_coordinator
+    device_coordinator = config_entry_data.device_coordinator
     user_coordinator = config_entry_data.user_coordinator
     base_coordinator = config_entry_data.base_coordinator
 
@@ -137,7 +137,7 @@ async def async_setup_entry(
             for sensor in EIGHT_USER_SENSORS
         )
         all_sensors.extend(
-            EightHeatSensor(entry, heat_coordinator, eight, user, sensor)
+            EightHeatSensor(entry, device_coordinator, eight, user, sensor)
             for sensor in EIGHT_HEAT_SENSORS
         )
 

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -285,6 +285,7 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
         if self._sensor == "bed_temperature":
             self._attr_icon = "mdi:thermometer"
             self._attr_device_class = SensorDeviceClass.TEMPERATURE
+            self._attr_state_class = SensorStateClass.MEASUREMENT
             self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         elif self._sensor in (NAME_MAP):
             self._attr_native_unit_of_measurement = NAME_MAP[self._sensor].measurement

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -127,7 +127,6 @@ async def async_setup_entry(
     eight = config_entry_data.api
     device_coordinator = config_entry_data.device_coordinator
     user_coordinator = config_entry_data.user_coordinator
-    base_coordinator = config_entry_data.base_coordinator
 
     all_sensors: list[SensorEntity] = []
 
@@ -140,16 +139,6 @@ async def async_setup_entry(
             EightHeatSensor(entry, device_coordinator, eight, user, sensor)
             for sensor in EIGHT_HEAT_SENSORS
         )
-
-    if eight.base_user:
-        all_sensors.append(EightUserSensor(
-            entry,
-            base_coordinator,
-            eight,
-            eight.base_user,
-            "base_preset",
-            base_entity=True
-        ))
 
     all_sensors.extend(
         EightRoomSensor(entry, user_coordinator, eight, sensor)
@@ -305,7 +294,6 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
             self._sensor == "sleep_stage"
             or self._sensor == "bed_state_type"
             or self._sensor == "side"
-            or self._sensor == "base_preset"
         ):
             # These have string values, leave the class None
             pass
@@ -333,8 +321,6 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
             return self._user_obj.last_sleep_score
         if self._sensor == "side":
             return self._user_obj.side
-        if self._sensor == "base_preset":
-            return self._user_obj.base_preset
         if self._sensor == "bed_temperature":
             return self._user_obj.current_values["bed_temp"]
         if self._sensor == "sleep_stage":

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -141,8 +141,15 @@ async def async_setup_entry(
             for sensor in EIGHT_HEAT_SENSORS
         )
 
-        if eight.has_base:
-            all_sensors.append(EightUserSensor(entry, base_coordinator, eight, user, "base_preset"))
+    if eight.base_user:
+        all_sensors.append(EightUserSensor(
+            entry,
+            base_coordinator,
+            eight,
+            eight.base_user,
+            "base_preset",
+            base_entity=True
+        ))
 
     all_sensors.extend(
         EightRoomSensor(entry, user_coordinator, eight, sensor)
@@ -279,9 +286,10 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
         eight: EightSleep,
         user: EightUser | None,
         sensor: str,
+        base_entity: bool = False
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(entry, coordinator, eight, user, sensor)
+        super().__init__(entry, coordinator, eight, user, sensor, base_entity)
         assert self._user_obj
 
         if self._sensor == "bed_temperature":

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -17,7 +17,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     UnitOfTemperature,
-    UnitOfTime,
     CONF_BINARY_SENSORS,
 )
 from homeassistant.core import HomeAssistant
@@ -138,6 +137,9 @@ async def async_setup_entry(
             EightHeatSensor(entry, heat_coordinator, eight, obj.user_id, sensor)
             for sensor in EIGHT_HEAT_SENSORS
         )
+
+        if eight.has_base:
+            all_sensors.append(EightUserSensor(entry, user_coordinator, eight, obj.user_id, "base_preset"))
 
     all_sensors.extend(
         EightRoomSensor(entry, user_coordinator, eight, sensor)
@@ -325,12 +327,12 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
             return self._user_obj.bed_state_type
         if "last" in self._sensor:
             return self._user_obj.last_sleep_score
-        if "side" == self._sensor:
+        if self._sensor == "side":
             return self._user_obj.side
-
+        if self._sensor == "base_preset":
+            return self._user_obj.base_preset
         if self._sensor == "bed_temperature":
             return self._user_obj.current_values["bed_temp"]
-
         if self._sensor == "sleep_stage":
             return self._user_obj.current_values["stage"]
 


### PR DESCRIPTION
This PR adds support for the base included in the Pod 4 Ultra:
- Expose model, hardware and software version
- Expose binary sensor for snore mitigation
- Expose number entities for head and feet angles
- Expose base preset (sleep, relaxing, or reading)

<img width="661" alt="Screenshot 2024-10-12 at 18 09 08" src="https://github.com/user-attachments/assets/9887e8e5-89dc-40f7-a0c7-7e0f86f99b1a">

While trying to make this work, I did quite a lot of refactoring:
- Fix linter warnings and various fixes based on type checks
- Remove unused or duplicate code
- [Fix blocking operation](https://github.com/lukas-clarke/eight_sleep/commit/63aa99d7486742d0104d89625e20a4a0b5eff6b9) that Home Assistant warns about
- [Rename heat_coordinator to device_coordinator](https://github.com/lukas-clarke/eight_sleep/commit/ab03b335ae3c7701f528973fea9fc53bb26f3f52) because it's used to update the device data - heat might be a legacy name?
- Improve the readability of EightUserSensor by assigning state and device classes explicitly
- Switch to [entity names](https://developers.home-assistant.io/docs/core/entity#entity-naming) everywhere. This will change the ID of newly added entities from `users_s_bed_presence` to `users_s_eight_sleep_side_bed_presence`, but it's been the mandatory way to name entities for over two years.