### PR TITLE
Send Home Assistant user agent

### DIFF
--- a/custom_components/eight_sleep/pyEight/constants.py
+++ b/custom_components/eight_sleep/pyEight/constants.py
@@ -8,7 +8,7 @@ Licensed under the MIT license.
 
 MAJOR_VERSION = 1
 MINOR_VERSION = 0
-SUB_MINOR_VERSION = 0
+SUB_MINOR_VERSION = 18
 __version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}.{SUB_MINOR_VERSION}"
 
 DEFAULT_TIMEOUT = 240
@@ -36,7 +36,7 @@ TOKEN_TIME_BUFFER_SECONDS = 120
 DEFAULT_API_HEADERS = {
     "content-type": "application/json",
     "connection": "keep-alive",
-    "user-agent": "Android App",
+    "user-agent": f"Home Assistant {__version__}",
     "accept-encoding": "gzip",
     "accept": "application/json",
     "host": "app-api.8slp.net",
@@ -45,7 +45,7 @@ DEFAULT_API_HEADERS = {
 
 DEFAULT_AUTH_HEADERS = {
     "content-type": "application/json",
-    "user-agent": "Android App",
+    "user-agent": f"Home Assistant {__version__}",
     "accept-encoding": "gzip",
     "accept": "application/json",
 }


### PR DESCRIPTION
Send "Home Assistant <version>" as the user agent, as requested by an Eight Sleep developer:

> Hi, I'm one of the devs that works on the 8S APIs.
>
>As noted in the thread, the user-agent wasn't the thing that was blocked. That being said, updating the user-agent to be reflective of the fact that it's Home Assistant would actually be useful for understanding usage and help us advocate internally for supporting third-party access officially. 
https://www.reddit.com/r/EightSleep/comments/1c6jy4s/comment/l0b04qn/