### PR TITLE
Add target temperature sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ There are a few possible sensor values for each Eight Sleep side. Some ones with
 | Bed State               | Side  | Percent     | Sort Of  | This value is pulled directly from the API and relates to the target heating level. While it may not seem to relate to anything, some people are able to use it to correlate a bed presence to. |
 | Bed State Type          | Side  | String      | Yes      | Options are: "off", "smart:bedtime", "smart:initial", "smart:final"                                                                                                                             |
 | Bed Temperature         | Side  | Temperature | Yes*     | Only accurate when the pod is on.                                                                                                                                                               |
+| Target Temperature      | Side  | Temperature | Yes      | The target temperature for the bed side in degrees.                                                                                                                                             |
 | Breath Rate             | Side  | Measurement | Yes      |                                                                                                                                                                                                 |
 | Heart Rate              | Side  | Measurement | Yes      |                                                                                                                                                                                                 |
 | HRV                     | Side  | Measurement | Yes      |                                                                                                                                                                                                 |
@@ -122,7 +123,6 @@ These values are updated every minute.
 ## TODO ##
 - Translate "Heat Set" and "Heat Increment" values to temperature values in degrees for easier use.
 - Add device actions, so they can be used instead of service calls.
-- Add the target temperature as a sensor
 - Add local device functionality for jailbroken devices using the steps in https://github.com/bobobo1618/ninesleep
 - Add icons.json file
 

--- a/custom_components/eight_sleep/const.py
+++ b/custom_components/eight_sleep/const.py
@@ -46,6 +46,12 @@ NAME_MAP = {
         device_class=SensorDeviceClass.TIMESTAMP,
         state_class=None
     ),
+    "target_heating_temp": NameMapEntity(
+        "Target Temperature",
+        "°C",
+        SensorDeviceClass.TEMPERATURE,
+        SensorStateClass.MEASUREMENT
+    ),
 }
 
 SERVICE_HEAT_SET = "heat_set"

--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -333,16 +333,16 @@ class EightSleep:
         tmp = None
         tmp2 = None
         for user in self.users.values():
-            if user.current_values["processing"]:
+            if user.current_session_processing:
                 if tmp is None:
-                    tmp = user.current_values["room_temp"]
+                    tmp = user.current_room_temp
                 else:
-                    tmp = (tmp + user.current_values["room_temp"]) / 2
+                    tmp = (tmp + user.current_room_temp) / 2
             else:
                 if tmp2 is None:
-                    tmp2 = user.current_values["room_temp"]
+                    tmp2 = user.current_room_temp
                 else:
-                    tmp2 = (tmp2 + user.current_values["room_temp"]) / 2
+                    tmp2 = (tmp2 + user.current_room_temp) / 2
 
         if tmp is not None:
             return tmp

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -38,6 +38,7 @@ class EightUser:  # pylint: disable=too-many-public-methods
         self.next_alarm_id = None
         self.bed_state_type = None
         self.current_side_temp = None
+        self.target_heating_temp = None
 
         # Variables to do dynamic presence
         self.presence: bool = False
@@ -734,6 +735,13 @@ class EightUser:  # pylint: disable=too-many-public-methods
         self.current_side_temp = self.device.convert_raw_bed_temp_to_degrees(
             current_side_temp_raw, "c"
         )
+
+        if self.target_heating_level is None:
+            self.target_heating_temp = None
+        else:
+            self.target_heating_temp = self.device.convert_raw_bed_temp_to_degrees(
+                self.target_heating_level, "c"
+            )
 
     async def set_bed_side(self, side) -> None:
         side = str(side).lower()

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -83,6 +83,7 @@ EIGHT_USER_SENSORS = [
     "current_hrv",
     "current_breath_rate",
     "bed_temperature",
+    "target_heating_temp",
     "sleep_stage",
     "next_alarm",
     "bed_state_type",
@@ -322,9 +323,9 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
         if self._sensor == "side":
             return self._user_obj.side
         if self._sensor == "bed_temperature":
-            return self._user_obj.current_values["bed_temp"]
+            return self._user_obj.current_bed_temp
         if self._sensor == "sleep_stage":
-            return self._user_obj.current_values["stage"]
+            return self._user_obj.current_sleep_stage
 
         return None
 


### PR DESCRIPTION
Add target temperature sensor, completing the TODO. Interestingly it varies a lot more than I expected:
![image](https://github.com/user-attachments/assets/4a1df2cc-6598-443e-9c9e-a0f1e202745c)

Also stop using the current_values property for accessing a single field. Using that resulted in all the current values being calculated over and over again.