### PR TITLE
Add alarm switches

### DIFF
--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -40,7 +40,7 @@ from .const import DOMAIN, NAME_MAP
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.NUMBER, Platform.SELECT]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.NUMBER, Platform.SELECT, Platform.SWITCH]
 
 DEVICE_SCAN_INTERVAL = timedelta(seconds=60)
 USER_SCAN_INTERVAL = timedelta(seconds=300)

--- a/custom_components/eight_sleep/binary_sensor.py
+++ b/custom_components/eight_sleep/binary_sensor.py
@@ -29,7 +29,6 @@ SNORE_MITIGATION_DESCRIPTION = BinarySensorEntityDescription(
     key="snore_mitigation",
     name="Snore Mitigaton",
     icon="mdi:account-alert",
-    device_class=BinarySensorDeviceClass.RUNNING,
 )
 
 

--- a/custom_components/eight_sleep/switch.py
+++ b/custom_components/eight_sleep/switch.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+from typing import Any, Awaitable, Callable
+
+from custom_components.eight_sleep.pyEight.user import EightUser
+
+from .pyEight.eight import EightSleep
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from . import EightSleepBaseEntity, EightSleepConfigEntryData
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    config_entry_data: EightSleepConfigEntryData = hass.data[DOMAIN][entry.entry_id]
+    eight = config_entry_data.api
+
+    entities: list[SwitchEntity] = []
+
+    for user in eight.users.values():
+        alarm_index = 1
+        for routine in user.routines:
+            for alarm in routine["alarms"]:
+                description = SwitchEntityDescription(
+                    key=f"alarm_{alarm_index}",
+                    name=f"Alarm {alarm_index}",
+                    icon="mdi:alarm",
+                )
+
+                attributes = {
+                    "time": alarm["timeWithOffset"]["time"],
+                    "days": routine["days"],
+                    "thermal": alarm["settings"]["thermal"],
+                    "vibration": alarm["settings"]["vibration"],
+                }
+
+                alarm_id = alarm["alarmId"]
+
+                entities.append(EightSwitchEntity(
+                    entry,
+                    config_entry_data.user_coordinator,
+                    eight,
+                    user,
+                    description,
+                    lambda user=user, alarm_id=alarm_id: user.get_alarm(alarm_id)["enabled"],
+                    lambda value, user=user, routine_id=routine["id"], alarm_id=alarm_id:
+                        user.set_alarm_enabled(routine_id, alarm_id, value),
+                    attributes))
+
+                alarm_index += 1
+
+    async_add_entities(entities)
+
+
+class EightSwitchEntity(EightSleepBaseEntity, SwitchEntity):
+    """Representation of an Eight Sleep switch entity."""
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: DataUpdateCoordinator,
+        eight: EightSleep,
+        user: EightUser | None,
+        entity_description: SwitchEntityDescription,
+        value_getter: Callable[[], bool | None],
+        switch_callback: Callable[[bool], Awaitable[None]],
+        attributes: dict[str, Any]
+    ) -> None:
+        super().__init__(entry, coordinator, eight, user, entity_description.key)
+        self.entity_description = entity_description
+        self._value_getter = value_getter
+        self._switch_callback = switch_callback
+        self._attr_extra_state_attributes = attributes
+
+    @property
+    def is_on(self) -> bool | None:
+        return self._value_getter()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self._switch_callback(True)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self._switch_callback(False)
+        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
This is the last big change I needed to get all my automations to work nicely: adding switches for alarms.

A switch will be created for each of the routines, named in sequential order:
<img width="335" alt="Screenshot 2024-10-25 at 16 20 35" src="https://github.com/user-attachments/assets/3c58dc7a-f29f-46e7-9f9e-2f173c78391b">

Further information about the alarms are available under attributes:
<img width="555" alt="Screenshot 2024-10-25 at 16 22 02" src="https://github.com/user-attachments/assets/c7aa84dc-446d-4bde-8dfc-d3ce40bd5f60">

The attributes can be used to show them however you wish on your dashboard:
<img width="309" alt="Screenshot 2024-10-25 at 16 22 52" src="https://github.com/user-attachments/assets/97bfa495-f394-446e-ad56-6c9d729b15ff">

