### PR TITLE
Add switch for next alarm

### DIFF
--- a/custom_components/eight_sleep/switch.py
+++ b/custom_components/eight_sleep/switch.py
@@ -87,17 +87,27 @@ class EightSwitchEntity(EightSleepBaseEntity, SwitchEntity):
             alarm_id = self._alarm_id or self._user_obj.next_alarm_id
             if alarm_id:
                 for routine in self._user_obj.routines:
+                    if "override" in routine:
+                        for alarm in routine["override"]["alarms"]:
+                            if alarm["alarmId"] == alarm_id:
+                                self._attr_extra_state_attributes["time"] = alarm["time"]
+                                self._attr_extra_state_attributes["days"] = "Tonight"
+                                self._attr_extra_state_attributes["thermal"] = alarm["settings"]["thermal"]
+                                self._attr_extra_state_attributes["vibration"] = alarm["settings"]["vibration"]
+                                return
+
                     for alarm in routine["alarms"]:
                         if alarm["alarmId"] == alarm_id:
                             self._attr_extra_state_attributes["time"] = alarm["timeWithOffset"]["time"]
                             self._attr_extra_state_attributes["days"] = routine["days"]
                             self._attr_extra_state_attributes["thermal"] = alarm["settings"]["thermal"]
                             self._attr_extra_state_attributes["vibration"] = alarm["settings"]["vibration"]
-            else:
-                self._attr_extra_state_attributes["time"] = None
-                self._attr_extra_state_attributes["days"] = None
-                self._attr_extra_state_attributes["thermal"] = None
-                self._attr_extra_state_attributes["vibration"] = None
+                            return
+
+        self._attr_extra_state_attributes.pop("time", None)
+        self._attr_extra_state_attributes.pop("days", None)
+        self._attr_extra_state_attributes.pop("thermal", None)
+        self._attr_extra_state_attributes.pop("vibration", None)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         if self._user_obj:


### PR DESCRIPTION
Toggling alarms stopped working some time ago because they introduced a new field: `disabledIndividually` (in addition to the already existing `enabled`).

While I was trying to understand how those two fields interact, I gained a pretty good understanding of how Eight Sleep handles "tonight's routine" in their app. Therefore I decided to add support for the "next alarm" switch, which will only affect the next morning. For example you can now toggle off tomorrow's alarm without toggling of the alarm for the rest of the days.

Also, the alarm attributes now update automatically. Previously they only changed when the integration was reloaded.

<img src="https://github.com/user-attachments/assets/19163126-a8f4-4dec-8fc1-f4deba722c49" width="400">
