### PR TITLE
Fix device registry deprecation

### DIFF
--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -170,7 +170,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # No users, cannot continue
         return False
 
-    dev_reg = await dr.async_get_registry(hass)
+    dev_reg = await dr.async_get(hass)
     assert eight.device_data
     device_data = {
         ATTR_MANUFACTURER: "Eight Sleep",

--- a/custom_components/eight_sleep/climate.py
+++ b/custom_components/eight_sleep/climate.py
@@ -65,8 +65,6 @@ class EightSleepThermostat(EightSleepBaseEntity, ClimateEntity):
     _attr_has_entity_name = True
     _attr_name = "Climate"
     _attr_hvac_modes = [HVACMode.HEAT_COOL, HVACMode.OFF]
-    _attr_min_temp = MIN_TEMP_F
-    _attr_max_temp = MAX_TEMP_F
     _attr_target_temperature_step = TEMP_STEP
     _attr_supported_features = (
         ClimateEntityFeature.TURN_ON
@@ -85,7 +83,14 @@ class EightSleepThermostat(EightSleepBaseEntity, ClimateEntity):
     ) -> None:
         """Initialize the thermostat."""
         super().__init__(entry, coordinator, eight, user, sensor)
-        self._attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
+        self._attr_temperature_unit = self.hass.config.units.temperature_unit
+        if self._attr_temperature_unit == UnitOfTemperature.CELSIUS:
+            self._attr_min_temp = MIN_TEMP_C
+            self._attr_max_temp = MAX_TEMP_C
+        else:
+            self._attr_min_temp = MIN_TEMP_F
+            self._attr_max_temp = MAX_TEMP_F
+
         # device data seems to be more up-to-date than user data
         heating_level_key = f"{user.corrected_side_for_key}TargetHeatingLevel"
         heating_level = self._eight.device_data.get(heating_level_key)


### PR DESCRIPTION
Fixing the async_get call to match latest HA documentation at https://developers.home-assistant.io/docs/device_registry_index/