### PR TITLE
don't await `dr.async_get`

### DIFF
--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -170,7 +170,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # No users, cannot continue
         return False
 
-    dev_reg = await dr.async_get(hass)
+    dev_reg = dr.async_get(hass)
     assert eight.device_data
     device_data = {
         ATTR_MANUFACTURER: "Eight Sleep",


### PR DESCRIPTION
`async_get` is not an async function so there is no need to await here.

Fixes error:
```
File "/usr/src/homeassistant/homeassistant/config_entries.py", line 749, in __async_setup_with_context
result = await component.async_setup_entry(hass, self)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/eight_sleep/init.py", line 173, in async_setup_entry
dev_reg = await dr.async_get(hass)
^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object DeviceRegistry can't be used in 'await' expression
```
