### PR TITLE
Remove routines from NAME_MAP

### DIFF
--- a/custom_components/eight_sleep/const.py
+++ b/custom_components/eight_sleep/const.py
@@ -53,10 +53,6 @@ NAME_MAP = {
         SensorDeviceClass.TEMPERATURE,
         SensorStateClass.MEASUREMENT
     ),
-    "routines": NameMapEntity(
-        "Routines",
-        state_class=None
-    ),
 }
 
 SERVICE_HEAT_SET = "heat_set"


### PR DESCRIPTION
Remove `routines` from `NAME_MAP`. This is causing the full state value of routines to be returned in EightUserSensor.native_value instead of the desired outcome of returning the number of routines (and then setting the full value as an attribute).
