### PR TITLE
Handle base sensor lookup when users are away.

### DIFF
--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -256,8 +256,14 @@ class EightSleep:
     @property
     def base_user(self) -> EightUser | None:
         """Return the user object for the base."""
-        if self.has_base:
-            return next(iter(self.users.values()))
+        if not self.has_base:
+            return
+        
+        for user in self.users.values():
+            if user.side != "away":
+                return user
+
+        _LOGGER.info("No base user found, it's likely all base users are 'away'.")
 
     async def start(self) -> bool:
         """Start api initialization."""


### PR DESCRIPTION
This is the simplest way to avoid looking up base sensor data when users are away. It'll resolve both #79 and #102 .