### PR TITLE
Multi pod support and fixes for away users

### DIFF
--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -127,6 +127,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         client_secret = entry.data[CONF_CLIENT_SECRET]
     else:
         client_secret = None
+    if CONF_DEVICE_ID in entry.data:
+        device_id = entry.data[CONF_DEVICE_ID]
+    else:
+        device_id = None
     eight = EightSleep(
         entry.data[CONF_USERNAME],
         entry.data[CONF_PASSWORD],
@@ -135,7 +139,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         client_secret,
         client_session=async_get_clientsession(hass),
         httpx_client=get_async_client(hass),
-        device_id=entry.data[CONF_DEVICE_ID],
+        device_id=device_id,
     )
     # Authenticate, build sensors
     try:

--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
+    CONF_DEVICE_ID,
     Platform,
 )
 from homeassistant.core import HomeAssistant
@@ -133,7 +134,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         client_id,
         client_secret,
         client_session=async_get_clientsession(hass),
-        httpx_client=get_async_client(hass)
+        httpx_client=get_async_client(hass),
+        device_id=entry.data[CONF_DEVICE_ID],
     )
     # Authenticate, build sensors
     try:
@@ -198,7 +200,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     dev_reg.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, _get_device_unique_id(eight))},
-        name=f"{entry.data[CONF_USERNAME]}'s Eight Sleep",
+        name=f"{entry.title} Eight Sleep Hub",
         **device_data,
     )
     for user in eight.users.values():
@@ -224,7 +226,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         dev_reg.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={(DOMAIN, _get_device_unique_id(eight, base_entity=True))},
-            name=f"{entry.data[CONF_USERNAME]}'s Base",
+            name=f"{entry.title} Base",
             via_device=(DOMAIN, _get_device_unique_id(eight)),
             **base_device_data,
         )

--- a/custom_components/eight_sleep/config_flow.py
+++ b/custom_components/eight_sleep/config_flow.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from .pyEight.eight import EightSleep
-from .pyEight.exceptions import RequestError
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -19,14 +17,21 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
     TextSelector,
     TextSelectorConfig,
     TextSelectorType,
 )
 
+from .pyEight.eight import EightSleep
+from .pyEight.exceptions import RequestError
+from .pyEight.household import EightHousehold
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+CONF_DEVICE_ID = "device_id"
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -51,19 +56,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def _validate_data(self, config: dict[str, str]) -> str | None:
-        """Validate input data and return any error."""
-        await self.async_set_unique_id(config[CONF_USERNAME].lower())
-        self._abort_if_unique_id_configured()
-        if CONF_CLIENT_ID in config:
-            client_id = config[CONF_CLIENT_ID]
-        else:
-            client_id = None
-        if CONF_CLIENT_SECRET in config:
-            client_secret = config[CONF_CLIENT_SECRET]
-        else:
-            client_secret = None
-        eight = EightSleep(
+    def __init__(self) -> None:
+        """Initialize the flow."""
+        self._validated_user_input: dict[str, Any] | None = None
+        self._device_options: dict[str, str] = {}
+        self.client: EightSleep | None = None
+
+    def _build_eight_client(self, config: dict[str, Any]) -> EightSleep:
+        """Create an EightSleep client from user provided config."""
+        client_id = config.get(CONF_CLIENT_ID)
+        client_secret = config.get(CONF_CLIENT_SECRET)
+
+        return EightSleep(
             config[CONF_USERNAME],
             config[CONF_PASSWORD],
             self.hass.config.time_zone,
@@ -73,26 +77,42 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             httpx_client=get_async_client(self.hass),
         )
 
+    async def _fetch_devices(self) -> dict[str, str]:
+        """Fetch available devices for the authenticated user.
+
+        Return a mapping of:
+            { "<device_id>": "<human-friendly label>" }
+
+        Example:
+            {
+                "pod_123": "Master Bedroom Pod",
+                "pod_456": "Guest Bedroom Pod",
+            }
+        """
+        household = EightHousehold(self.client)
+        return await household.get_devices()
+
+    async def _validate_credentials(self, config: dict[str, Any]) -> str | None:
+        """Validate input data and return any error string (or None)."""
+        self.client = self._build_eight_client(config)
+
         try:
-            await eight.refresh_token()
+            await self.client.refresh_token()
         except RequestError as err:
             if "401" in str(err):
                 return "Credentials are invalid"
-            else:
-                return str(err)
+            return str(err)
 
         return None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the initial step."""
+        """Handle the initial step (authenticate)."""
         if user_input is None:
-            return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
-            )
+            return self.async_show_form(step_id="user", data_schema=STEP_USER_DATA_SCHEMA)
 
-        if (err := await self._validate_data(user_input)) is not None:
+        if (err := await self._validate_credentials(user_input)) is not None:
             return self.async_show_form(
                 step_id="user",
                 data_schema=STEP_USER_DATA_SCHEMA,
@@ -100,14 +120,106 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 description_placeholders={"error": err},
             )
 
-        return self.async_create_entry(title=user_input[CONF_USERNAME], data=user_input)
+        # Credentials are valid; store them temporarily for the next step.
+        self._validated_user_input = user_input
+
+        # Fetch devices to allow user to select which device this config entry represents.
+        try:
+            self._device_options = await self._fetch_devices()
+        except Exception as err:  # noqa: BLE001 (surface as flow error)
+            _LOGGER.exception("Error fetching Eight Sleep devices: %s", err)
+            return self.async_show_form(
+                step_id="user",
+                data_schema=STEP_USER_DATA_SCHEMA,
+                errors={"base": "Unable to fetch devices"},
+                description_placeholders={"error": "Unable to fetch devices"},
+            )
+
+        # If there are no devices returned, fail fast with a clear message.
+        if not self._device_options:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=STEP_USER_DATA_SCHEMA,
+                errors={"base": "No devices found for this account"},
+                description_placeholders={"error": "No devices found for this account"},
+            )
+
+        # If only one device exists, skip the selection step.
+        if len(self._device_options) == 1:
+            device_id = next(iter(self._device_options))
+            return await self._create_entry_for_device(device_id)
+
+        return await self.async_step_device()
+
+    async def async_step_device(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the device selection step."""
+        if self._validated_user_input is None:
+            # If HA re-enters this step unexpectedly, bounce back to auth.
+            return await self.async_step_user()
+
+        if user_input is not None:
+            device_id = user_input[CONF_DEVICE_ID]
+            return await self._create_entry_for_device(device_id)
+
+        return self.async_show_form(
+            step_id="device",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_DEVICE_ID): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                {"value": dev_id, "label": label}
+                                for dev_id, label in self._device_options.items()
+                            ],
+                            mode="dropdown",
+                        )
+                    )
+                }
+            ),
+        )
+
+    async def _create_entry_for_device(self, device_id: str) -> FlowResult:
+        """Create the config entry for the selected device."""
+        assert self._validated_user_input is not None
+
+        # Use device_id as the unique_id so the same physical device can't be added twice.
+        await self.async_set_unique_id(device_id)
+        self._abort_if_unique_id_configured()
+
+        data = dict(self._validated_user_input)
+        data[CONF_DEVICE_ID] = device_id
+
+        title = self._device_options.get(device_id) or data[CONF_USERNAME]
+
+        return self.async_create_entry(title=title, data=data)
 
     async def async_step_import(self, import_config: dict) -> FlowResult:
-        """Handle import."""
-        if (err := await self._validate_data(import_config)) is not None:
+        """Handle import.
+
+        NOTE: Import can't prompt for device selection. If you need device binding when using
+        YAML import, include `device_id:` in your YAML and we'll treat it as already selected.
+        """
+        if (err := await self._validate_credentials(import_config)) is not None:
             _LOGGER.error("Unable to import configuration.yaml configuration: %s", err)
             return self.async_abort(reason=err, description_placeholders={"error": err})
 
+        # If device_id is provided in YAML, bind the entry to that device.
+        if CONF_DEVICE_ID in import_config and import_config[CONF_DEVICE_ID]:
+            await self.async_set_unique_id(import_config[CONF_DEVICE_ID])
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(
+                title=import_config.get(CONF_USERNAME, "Eight Sleep"),
+                data=import_config,
+            )
+
+        # Otherwise, keep old behavior (one entry per username). This is imperfect for multi-device,
+        # but avoids breaking existing YAML-based setups.
+        await self.async_set_unique_id(import_config[CONF_USERNAME].lower())
+        self._abort_if_unique_id_configured()
+
         return self.async_create_entry(
-            title=import_config[CONF_USERNAME], data=import_config
+            title=import_config[CONF_USERNAME],
+            data=import_config,
         )

--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -410,8 +410,7 @@ class EightSleep:
         url = f"{CLIENT_API_URL}/users/me"
         dlist = await self.api_request("get", url)
 
-       self.device_id =  dlist["user"]["devices"][0]
-        
+        self.device_id =  dlist["user"]["devices"][0]
 
     async def update_device_data(self) -> None:
         """Update device data json."""

--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -305,6 +305,10 @@ class EightSleep:
             self._internal_session = True
 
         await self.token
+        
+        if self.device_id is None:
+            await self.fetch_device_id()
+
         await self.update_device_data()
         await self.assign_users()
 
@@ -400,6 +404,14 @@ class EightSleep:
             self._has_speaker = True
 
         _LOGGER.debug(f"Device: {self.device_id}, Pod: {self._is_pod}, Base: {self._has_base}, Speaker: {self._has_speaker}")
+
+    async def fetch_device_id(self) -> None:
+        """Fetch device id for backwards compatibility."""
+        url = f"{CLIENT_API_URL}/users/me"
+        dlist = await self.api_request("get", url)
+
+       self.device_id =  dlist["user"]["devices"][0]
+        
 
     async def update_device_data(self) -> None:
         """Update device data json."""

--- a/custom_components/eight_sleep/pyEight/household.py
+++ b/custom_components/eight_sleep/pyEight/household.py
@@ -1,0 +1,39 @@
+"""
+pyeight.household
+~~~~~~~~~~~~~~~~~~~~
+Provides household data for Eight Sleep
+Copyright (c) 2022-2025 <https://github.com/lukas-clarke/pyEight>
+Licensed under the MIT license.
+"""
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from .constants import APP_API_URL, CLIENT_API_URL
+
+if TYPE_CHECKING:
+    from .eight import EightSleep
+
+class EightHousehold:
+    def __init__(self, client: "EightSleep", user_id: Optional[str] = None):
+        self.user_id: str | None = user_id
+        self.client = client
+        self.devices: dict[str, str] = {}
+
+    async def get_user_id(self) -> str:
+        url = f"{CLIENT_API_URL}/users/me"
+        user_data = await self.client.api_request("get", url)
+        return user_data["user"]["userId"]
+
+    async def get_devices(self) -> dict[str, str]:
+        user_id = await self.get_user_id() if self.user_id is None else self.user_id
+
+        url = APP_API_URL + f"v1/household/users/{user_id}/summary"
+        data = await self.client.api_request("GET", url)
+
+        self.devices = {}
+        for house_set in data["households"][0]["sets"]:
+            device = house_set["devices"][0]
+            self.devices[device["deviceId"]] = device["deviceName"]
+
+        return self.devices
+        

--- a/custom_components/eight_sleep/pyEight/tests/test_auth.py
+++ b/custom_components/eight_sleep/pyEight/tests/test_auth.py
@@ -148,7 +148,7 @@ class TestAuth(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(eight._token.bearer_token, "fake_access_token")
         # Check token's main_id directly
         self.assertEqual(eight._token.main_id, "fake_user_id_main")
-        self.assertIn("fake_device_id_123", eight._device_ids)
+        self.assertEqual"fake_device_id_123", eight.device_id)
         self.assertTrue(eight._is_pod)
         self.assertIn("user_left_abc", eight.users)
         self.assertIn("user_right_def", eight.users)

--- a/custom_components/eight_sleep/pyEight/tests/test_auth.py
+++ b/custom_components/eight_sleep/pyEight/tests/test_auth.py
@@ -148,7 +148,7 @@ class TestAuth(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(eight._token.bearer_token, "fake_access_token")
         # Check token's main_id directly
         self.assertEqual(eight._token.main_id, "fake_user_id_main")
-        self.assertEqual"fake_device_id_123", eight.device_id)
+        self.assertEqual("fake_device_id_123", eight.device_id)
         self.assertTrue(eight._is_pod)
         self.assertIn("user_left_abc", eight.users)
         self.assertIn("user_right_def", eight.users)

--- a/custom_components/eight_sleep/pyEight/tests/test_eight.py
+++ b/custom_components/eight_sleep/pyEight/tests/test_eight.py
@@ -41,7 +41,7 @@ class TestEightSleep(unittest.IsolatedAsyncioTestCase):
         eight._api_session = mock_aiohttp_session_instance
         await eight.fetch_device_list()
 
-        self.assertEqual(eight._device_ids, ["dev123"])
+        self.assertEqual(eight.device_id, "dev123")
         self.assertTrue(eight._is_pod)
         self.assertTrue(eight._has_base)
         mock_aiohttp_session_instance.request.assert_called_once_with(
@@ -95,7 +95,7 @@ class TestEightSleep(unittest.IsolatedAsyncioTestCase):
 
         eight = EightSleep(self.email, self.password, self.timezone)
         eight._api_session = mock_aiohttp_session_instance
-        eight._device_ids = ["dev123"] # Pre-set device ID for the test
+        eight.device_id = "dev123" # Pre-set device ID for the test
 
         await eight.assign_users()
 
@@ -122,7 +122,7 @@ class TestEightSleep(unittest.IsolatedAsyncioTestCase):
 
         eight = EightSleep(self.email, self.password, self.timezone)
         eight._api_session = mock_aiohttp_session_instance
-        eight._device_ids = ["dev123"] # Pre-set device ID
+        eight.device_id = "dev123" # Pre-set device ID
 
         await eight.update_device_data()
 

--- a/custom_components/eight_sleep/translations/en.json
+++ b/custom_components/eight_sleep/translations/en.json
@@ -15,6 +15,13 @@
           "password": "Password",
           "username": "Username"
         }
+      },
+      "device": {
+        "title": "Select Eight Sleep Pod",
+        "description": "Choose which Eight Sleep device you want to add.",
+        "data": {
+          "device_id": "Pod name"
+        }
       }
     }
   },


### PR DESCRIPTION
This PR adds support for selecting which Eight Sleep pod to add when an account has multiple devices. It also fixes an issue where the integration assumed the authenticated account’s default device was the one being controlled, ensuring the correct pod is now targeted for all API calls. Additionally, for newly added devices - the name of the device will have the "Pod name" as the prefix instead of the authenticated user's email.

<img width="396" height="308" alt="image" src="https://github.com/user-attachments/assets/85517be5-c4de-461b-9222-0037f59f5635" />

This has solved my issues with multiple pods on my account, so I'm expecting this to resolve #39.