### PR TITLE
Fix one-off alarm management and improve alarm handling

### DIFF
--- a/custom_components/eight_sleep/services.yaml
+++ b/custom_components/eight_sleep/services.yaml
@@ -147,6 +147,8 @@ set_routine_bedtime:
         time:
 
 set_one_off_alarm:
+  name: Set One-Off Alarm
+  description: Sets a one-off alarm for the specified time.
   target:
     entity:
       integration: eight_sleep


### PR DESCRIPTION
## Summary

When setting a 1-off alarm, I was seeing my routine alarms duplicated 3-4 times and multiple 1-off alarms created when calling the service. Sometimes the 1-off alarm also replaced my routines entirely. Been running this for several days and things are working smoothly now.

- Fix `set_one_off_alarm` to preserve existing one-off alarms instead of replacing them, and add debounce to prevent duplicate API calls when HA targets multiple entities
- Add one-off alarm tracking - parse `oneOffAlarms` from the routines API response and create switch entities for them
- Handle one-off alarm enable/disable via `set_alarm_enabled` with proper API payload
- Fix missing `alarmId` in routine alarm override creation
- Improve `update_routines_data` with null safety and better error handling
- Replace exception with warning when alarm ID not found (prevents crashes from stale alarm references)

## Test plan
- [ ] Set a one-off alarm via the `set_one_off_alarm` service and verify only one alarm is created (not duplicated)
- [ ] Verify one-off alarm switch entities appear and reflect correct on/off state
- [ ] Toggle a one-off alarm switch on/off and verify the API call succeeds
- [ ] Verify routine alarm switches still work correctly (enable/disable)
- [ ] Verify `update_routines_data` handles missing/null fields without errors
- [ ] Verify alarm override creation includes `alarmId` field