### PR TITLE
Add ability to delete device from UI

### DIFF
--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -256,12 +256,14 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     return unload_ok
 
+
 async def async_remove_config_entry_device(
     hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
 ) -> bool:
     """Remove a config entry from a device."""
     return True
-    
+
+
 class EightSleepBaseEntity(CoordinatorEntity[DataUpdateCoordinator]):
     """The base Eight Sleep entity class."""
 

--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -256,7 +256,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     return unload_ok
 
-
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Remove a config entry from a device."""
+    return True
+    
 class EightSleepBaseEntity(CoordinatorEntity[DataUpdateCoordinator]):
     """The base Eight Sleep entity class."""
 


### PR DESCRIPTION
**Problem:** 
As of right now there is no way to remove any mattress "side" devices that the integration had added previously, even if they were deleted in the official app and therefore no longer exist.

For example, if you add a guest, the integration will create a device for them. But then if you remove that guest via the official Eight Sleep app, the device will still show in the integration devices list with no way to remove them (only disable), despite the Eight Sleep API no longer returning that "side" device.

**This PR Fix:** 
With this change, removing such orphan devices is possible via the GUI using the built-in Home Assistant handling [as described in the docs here](https://developers.home-assistant.io/docs/device_registry_index#removing-devices).

The nice thing is this literally just requires adding a few lines for the built in handler and Home Assistant handles the rest.

### **Behavior scenarios:**
 - The user deletes a device that was removed via the official Eight Sleep app:
   - Result: The device is removed and won't re-appear because it's gone from the official API response
 - The user deletes a device that still exists in the official app:
   - Result: The device will be re-created upon reloading

<img width="400" height="661" alt="image" src="https://github.com/user-attachments/assets/0f2343a0-45ce-44a1-abe3-121f1a41e8b5" />

<img width="300" height="526" alt="image" src="https://github.com/user-attachments/assets/5942a352-6faa-4f12-b8f9-da751fd6a516" />

