### PR TITLE
fix: improve bed_presence reliability when HR trend data goes stale

### DIFF
--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -233,8 +233,18 @@ class EightUser:  # pylint: disable=too-many-public-methods
 
     @property
     def bed_presence(self) -> bool:
-        """Return true/false for bed presence based on recent heart rate data."""
+        """Return true/false for bed presence.
 
+        Uses heart rate trend data as the primary signal. When HR data goes
+        stale (10-30 min old), falls back to checking the device-level bed
+        state type. This prevents false negatives when the Eight Sleep cloud
+        API temporarily stops updating trend data during an active sleep
+        session.
+
+        The fallback only extends an existing session (recent HR data that
+        went stale). It does not trigger presence for pre-warming schedules
+        where no HR data was recorded in the current session.
+        """
         timeseries = self._trend_timeseries()
         if not timeseries or "heartRate" not in timeseries:
             return False
@@ -243,11 +253,27 @@ class EightUser:  # pylint: disable=too-many-public-methods
         _LOGGER.debug(f"Last heart rate: {heart_rate_entry} for {self.user_id}")
         heart_rate_time = datetime.fromisoformat(heart_rate_entry[0].replace('Z', '+00:00'))
 
-        time_difference = datetime.now(timezone.utc) - heart_rate_time
+        age_seconds = (datetime.now(timezone.utc) - heart_rate_time).total_seconds()
 
-        # Consider the person present if the last heart rate reading was within the last 10 minutes
-        # This assumes that trend are updated every 5 minutes
-        return time_difference.total_seconds() < 600
+        # Primary: fresh HR data confirms presence
+        if age_seconds < 600:
+            return True
+
+        # Fallback: HR data is 10-30 min stale, but the device reports an
+        # active sleep session. The cloud trend API likely lagged -- keep
+        # presence True to avoid false negatives.
+        # This does NOT trigger for pre-warming (last HR would be from a
+        # previous night, age >> 1800) or when no HR was ever recorded.
+        if age_seconds < 1800:
+            state_type = self.bed_state_type
+            if state_type and state_type.startswith("smart:"):
+                _LOGGER.debug(
+                    f"HR stale ({age_seconds:.0f}s) but device in '{state_type}' "
+                    f"for {self.user_id} -- extending presence"
+                )
+                return True
+
+        return False
 
     @property
     def target_heating_level(self) -> int | None:


### PR DESCRIPTION
## Problem

`bed_presence` relies solely on heart rate trend data from the Eight Sleep cloud API with a hard 10-minute freshness window. When the cloud API temporarily stops updating trend data during an active sleep session, `bed_presence` incorrectly returns `False` — even though the person is physically in bed and device-level sensors (`bed_state`, `bed_state_type`) confirm it.

This is the issue described in #114.

### Evidence from a live system

| Sensor | Value | Updating? |
|--------|-------|-----------|
| `bed_state` (device-level) | -3 (actively warming) | ✅ Every 60s |
| `bed_state_type` (device-level) | `smart:bedtime` | ✅ |
| `bed_presence` (HR trend) | `False` | ❌ Stuck for 1.5 hours |
| `heart_rate` (trend) | `unknown` | ❌ Stale |

Person was physically in bed the entire time. The device knew it. The presence sensor didn't.

## Fix

When HR trend data goes stale (10-30 min old), check if the device reports an active sleep session (`bed_state_type` starts with `"smart:"`). If so, maintain presence — the cloud API likely lagged, not the person leaving.

### Why this is safe

The fallback **only extends an existing session** where HR data was recently valid:

| Scenario | HR Age | state_type | Result | Correct? |
|----------|--------|------------|--------|----------|
| Normal bedtime, API healthy | <10m | `smart:bedtime` | True | ✅ |
| In bed, HR stale 15m (THE BUG) | 15m | `smart:bedtime` | **True** | ✅ Fixed |
| Pre-warming, nobody in bed | 8h+ (last night) | `smart:bedtime` | False | ✅ No regression |
| Left bed, schedule still active | 15m | `smart:bedtime` | True | ⚠️ Up to 30m delay |
| Left bed, schedule ended | 15m | `off` | False | ✅ |
| In bed, HR stale 45m+ | 45m | `smart:bedtime` | False | ⚠️ Still breaks |

### Trade-off

- **Gains:** Covers the most common failure mode (HR trend API lags 10-30m during active sleep)
- **Cost:** False-positive window when leaving bed extends from 10m to up to 30m if schedule stays active
- **No regression:** Pre-warming and previous-night scenarios stay correct (HR age >> 1800s)

## Longer-term: direct presence signal

The device endpoint (`/v1/devices/{id}`) already returns `{side}PresenceEnd` — a real-time device-level timestamp. If it also contains `{side}PresenceStart` or a live presence boolean, that would be a far more reliable signal than any HR-based heuristic. Filed #119 to investigate.

## Test plan

- [ ] Verify normal bedtime presence detection still works (HR fresh < 10m)
- [ ] Verify pre-warming does NOT trigger false presence (HR from previous night, age >> 30m)
- [ ] Verify stale HR (10-30m) during active `smart:bedtime` maintains presence
- [ ] Verify presence correctly drops after 30m of stale HR even with active schedule
- [ ] Verify leaving bed with schedule ending (`off`) correctly returns False