### PR TITLE
Migrate alarm system to new API with dynamic entities, dismiss & snooze buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 .idea/
 # ignoring md files so that context files can be created here
 *.md
+
+# Dev/exploration scripts (never push)
+.dev/

--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -43,6 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.CLIMATE,
     Platform.MEDIA_PLAYER,
     Platform.NUMBER,

--- a/custom_components/eight_sleep/button.py
+++ b/custom_components/eight_sleep/button.py
@@ -1,0 +1,68 @@
+"""Eight Sleep button entities for alarm actions."""
+
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from . import EightSleepBaseEntity, EightSleepConfigEntryData
+from .const import DOMAIN
+from .pyEight.eight import EightSleep
+from .pyEight.user import EightUser
+
+
+BUTTON_DESCRIPTIONS = [
+    ButtonEntityDescription(
+        key="alarm_dismiss",
+        name="Dismiss Alarm",
+        icon="mdi:alarm-check",
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    config_entry_data: EightSleepConfigEntryData = hass.data[DOMAIN][entry.entry_id]
+    eight = config_entry_data.api
+
+    entities: list[ButtonEntity] = []
+
+    for user in eight.users.values():
+        for description in BUTTON_DESCRIPTIONS:
+            entities.append(
+                EightAlarmButton(
+                    entry,
+                    config_entry_data.user_coordinator,
+                    eight,
+                    user,
+                    description,
+                )
+            )
+
+    async_add_entities(entities)
+
+
+class EightAlarmButton(EightSleepBaseEntity, ButtonEntity):
+    """Button to dismiss the currently active alarm."""
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: DataUpdateCoordinator,
+        eight: EightSleep,
+        user: EightUser,
+        entity_description: ButtonEntityDescription,
+    ) -> None:
+        super().__init__(entry, coordinator, eight, user, entity_description.key)
+        self.entity_description = entity_description
+
+    async def async_press(self) -> None:
+        if self._user_obj is None:
+            return
+
+        await self._user_obj.alarm_dismiss()
+        await self.coordinator.async_request_refresh()

--- a/custom_components/eight_sleep/button.py
+++ b/custom_components/eight_sleep/button.py
@@ -20,6 +20,11 @@ BUTTON_DESCRIPTIONS = [
         name="Dismiss Alarm",
         icon="mdi:alarm-check",
     ),
+    ButtonEntityDescription(
+        key="alarm_snooze",
+        name="Snooze Alarm",
+        icon="mdi:alarm-snooze",
+    ),
 ]
 
 
@@ -47,7 +52,7 @@ async def async_setup_entry(
 
 
 class EightAlarmButton(EightSleepBaseEntity, ButtonEntity):
-    """Button to dismiss the currently active alarm."""
+    """Button to dismiss or snooze the currently active alarm."""
 
     def __init__(
         self,
@@ -64,5 +69,9 @@ class EightAlarmButton(EightSleepBaseEntity, ButtonEntity):
         if self._user_obj is None:
             return
 
-        await self._user_obj.alarm_dismiss()
+        if self.entity_description.key == "alarm_dismiss":
+            await self._user_obj.alarm_dismiss()
+        elif self.entity_description.key == "alarm_snooze":
+            await self._user_obj.alarm_snooze(self._user_obj.snooze_minutes)
+
         await self.coordinator.async_request_refresh()

--- a/custom_components/eight_sleep/number.py
+++ b/custom_components/eight_sleep/number.py
@@ -3,6 +3,7 @@ from homeassistant.components.number import NumberEntity, NumberEntityDescriptio
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from custom_components.eight_sleep import EightSleepBaseEntity, EightSleepConfigEntryData
@@ -30,6 +31,16 @@ HEAD_DESCRIPTION = NumberEntityDescription(
     icon="mdi:head",
 )
 
+SNOOZE_MINUTES_DESCRIPTION = NumberEntityDescription(
+    key="alarm_snooze_minutes",
+    native_unit_of_measurement="min",
+    native_max_value=30,
+    native_min_value=5,
+    native_step=1,
+    name="Alarm Snooze Minutes",
+    icon="mdi:alarm-snooze",
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -39,6 +50,21 @@ async def async_setup_entry(
     coordinator = config_entry_data.base_coordinator
 
     entities: list[NumberEntity] = []
+
+    # Add snooze minutes number entity for each user
+    for user in eight.users.values():
+        entities.append(
+            EightNumberEntity(
+                entry,
+                config_entry_data.user_coordinator,
+                eight,
+                user,
+                SNOOZE_MINUTES_DESCRIPTION,
+                lambda u=user: u.snooze_minutes,
+                lambda value, u=user: setattr(u, 'snooze_minutes', int(value)),
+                base_entity=False,
+            )
+        )
 
     user = eight.base_user
     if user:
@@ -71,7 +97,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class EightNumberEntity(EightSleepBaseEntity, NumberEntity):
+class EightNumberEntity(EightSleepBaseEntity, NumberEntity, RestoreEntity):
 
     def __init__(
         self,
@@ -81,12 +107,23 @@ class EightNumberEntity(EightSleepBaseEntity, NumberEntity):
         user: EightUser | None,
         entity_description: NumberEntityDescription,
         value_getter: Callable[[], float | None],
-        set_value_callback: Callable[[float], None]
+        set_value_callback: Callable[[float], None],
+        base_entity: bool = True,
     ):
-        super().__init__(entry, coordinator, eight, user, entity_description.key, base_entity=True)
+        super().__init__(entry, coordinator, eight, user, entity_description.key, base_entity=base_entity)
         self.entity_description = entity_description
         self._value_getter = value_getter
         self._set_value_callback = set_value_callback
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous value on startup."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state not in (None, "unknown", "unavailable"):
+            try:
+                self._set_value_callback(float(last_state.state))
+            except (ValueError, TypeError):
+                pass
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -13,7 +13,6 @@ import logging
 import statistics
 from typing import TYPE_CHECKING, Any
 
-from .exceptions import RequestError
 from .constants import APP_API_URL, DATE_FORMAT, DATE_TIME_ISO_FORMAT, CLIENT_API_URL, POSSIBLE_SLEEP_STAGES
 from .exceptions import RequestError
 from .util import heating_level_to_temp
@@ -35,7 +34,8 @@ class EightUser:  # pylint: disable=too-many-public-methods
         self._user_profile: dict[str, Any] = {}
         self._base_data: dict[str, Any] = {}
         self.trends: list[dict[str, Any]] = []
-        self.routines: list[dict[str, Any]] = []
+        self.alarms: list[dict[str, Any]] = []
+        self.routines: list[dict[str, Any]] = []  # Kept for backward compat, always empty now
         self.smart_schedule: dict[str, Any] | None = None
         self.next_alarm = None
         self.next_alarm_id = None
@@ -143,56 +143,28 @@ class EightUser:  # pylint: disable=too-many-public-methods
             return None
         return self.trends[-(trend_num + 1)].get("processing", False)
 
-    def _get_routine(self, id: str) -> dict[str, Any]:
-        """Get routine data for the specified ID."""
-        for routine in self.routines:
-            if routine["id"] == id:
-                return routine
-
-        raise Exception(f"Routine with ID {id} not found")
+    def _get_alarm(self, alarm_id: str) -> dict[str, Any]:
+        """Get alarm data for the specified ID from the new alarms API."""
+        for alarm in self.alarms:
+            if alarm["id"] == alarm_id:
+                return alarm
+        raise Exception(f"Alarm with ID {alarm_id} not found")
 
     def get_alarm_enabled(self, id: str | None) -> bool:
         """Get alarm enabled for the specified ID.
         If no ID is specified, the next alarm will be used."""
-        check_next_alarm = id is None
-        if check_next_alarm:
+        if id is None:
             if self.next_alarm_id:
                 id = self.next_alarm_id
             else:
                 return False
 
-        # There are two fields that represent the state of an alarm:
-        #
-        # "enabled" represents whether the alarm will be active next time.
-        # We use this when displaying the next alarm as it can be toggled
-        # on/off independently of your routine.
-        #
-        # "disabledIndividually" represents whether the user turned off the alarm
-        # for all days of a routine. We use this when displaying regular alarms.
-        for routine in self.routines:
-            if "override" in routine:
-                for alarm in routine["override"]["alarms"]:
-                    if alarm["alarmId"] == id:
-                        return alarm["enabled"] if check_next_alarm else not alarm["disabledIndividually"]
+        for alarm in self.alarms:
+            if alarm["id"] == id:
+                return alarm.get("enabled", False)
 
-            for alarm in routine["alarms"]:
-                if alarm["alarmId"] == id:
-                    return alarm["enabled"] if check_next_alarm else not alarm["disabledIndividually"]
-
-        raise Exception(f"Alarm with ID {id} not found")
-
-    def _get_next_alarm_routine_id(self) -> str:
-        for routine in self.routines:
-            if "override" in routine:
-                for alarm in routine["override"]["alarms"]:
-                    if alarm["alarmId"] == self.next_alarm_id:
-                        return routine["id"]
-
-            for alarm in routine["alarms"]:
-                if alarm["alarmId"] == self.next_alarm_id:
-                    return routine["id"]
-
-        raise Exception(f"Alarm with ID {self.next_alarm_id} not found")
+        _LOGGER.warning("Alarm with ID %s not found in alarms list", id)
+        return False
 
     @property
     def user_profile(self) -> dict[str, Any] | None:
@@ -724,7 +696,7 @@ class EightUser:  # pylint: disable=too-many-public-methods
                 _LOGGER.debug(f"User {self.user_id} Smart Schedule: {self.smart_schedule}")
 
         except Exception as e:
-             _LOGGER.warning(f"Error fetching temperature data for {self.user_id}: {e}")
+            _LOGGER.warning(f"Error fetching temperature data for {self.user_id}: {e}")
 
 
     async def set_bed_side(self, side) -> None:
@@ -824,88 +796,68 @@ class EightUser:  # pylint: disable=too-many-public-methods
         await self.device.api_request("PUT", url, data=data)
 
     async def alarm_snooze(self, snooze_minutes: int):
-        """Snoozes the user alarm for the specified minutes"""
+        """Snoozes the user alarm for the specified minutes.
+
+        PUT /v1/users/{userId}/alarms/{alarmId}/snooze
+        Request: {"snoozeMinutes": 9, "ignoreDeviceErrors": false}
+        Response: 200 empty body (Content-Length: 0) or 409 if not ringing
+        """
         if not self.next_alarm_id:
             raise Exception(f"No next alarm ID set for {self.user_id}")
-        url = APP_API_URL + f"v1/users/{self.user_id}/routines"
-        data = {
-            "alarm": {"alarmId": self.next_alarm_id, "snoozeForMinutes": snooze_minutes}
-        }
+        url = APP_API_URL + f"v1/users/{self.user_id}/alarms/{self.next_alarm_id}/snooze"
+        data = {"snoozeMinutes": snooze_minutes, "ignoreDeviceErrors": False}
         await self.device.api_request("PUT", url, data=data)
 
     async def alarm_stop(self):
-        """Stops the next user alarm"""
-        if not self.next_alarm_id:
-            raise Exception(f"No next alarm ID set for {self.user_id}")
-        url = APP_API_URL + f"v1/users/{self.user_id}/routines"
-        data = {"alarm": {"alarmId": self.next_alarm_id, "stopped": True}}
-        await self.device.api_request("PUT", url, data=data)
+        """Stops the next user alarm. Uses dismiss endpoint (no separate stop in API)."""
+        await self.alarm_dismiss()
 
     async def alarm_dismiss(self):
-        """Dismisses the next user alarm"""
+        """Dismisses the next user alarm.
+
+        PUT /v1/users/{userId}/alarms/{alarmId}/dismiss
+        Request: {"ignoreDeviceErrors": false}
+        Response: 200 with alarm object (or 409 if alarm not ringing)
+        """
         if not self.next_alarm_id:
             raise Exception(f"No next alarm ID set for {self.user_id}")
-        url = APP_API_URL + f"v1/users/{self.user_id}/routines"
-        data = {"alarm": {"alarmId": self.next_alarm_id, "dismissed": True}}
+        url = APP_API_URL + f"v1/users/{self.user_id}/alarms/{self.next_alarm_id}/dismiss"
+        data = {"ignoreDeviceErrors": False}
         await self.device.api_request("PUT", url, data=data)
 
     async def set_alarm_enabled(self, routine_id: str | None, alarm_id: str | None, enabled: bool) -> None:
         """Enables or disables the alarm.
-        If no ID is specified, the next alarm will be used."""
-        if routine_id and alarm_id:
-            await self._set_alarm_enabled(routine_id, alarm_id, enabled)
+        routine_id is ignored (kept for backward compat). Uses new alarms API.
+        Sends the full alarm object as required by the API.
+
+        PUT /v1/users/{userId}/alarms/{alarmId}
+        Request (full alarm object, with server-computed fields stripped):
+        {
+            "id": "uuid",
+            "enabled": false,
+            "time": "07:00:00",
+            "repeat": {"enabled": true, "weekDays": {"monday": true, ...}},
+            "thermal": {"enabled": true, "temperature": -10},
+            "vibration": {"enabled": true, "level": 50, "pattern": "rise", "duration": 300},
+            "snoozing": false
+        }
+        Response: 200 with updated alarm object
+        """
+        target_id = alarm_id or self.next_alarm_id
+        if target_id is None:
+            _LOGGER.warning("No alarm ID available to toggle for user %s", self.user_id)
             return
-        if self.next_alarm_id is None:
-            # We don't do anything for now if there is no next alarm
-            return
-        routine_id = self._get_next_alarm_routine_id()
-        routine = self._get_routine(routine_id)
-        # If there is already an override, toggle it
-        if "override" in routine:
-            await self._set_alarm_enabled(routine_id, self.next_alarm_id, enabled)
-            return
-        # Otherwise create a new override
-        for alarm in routine["alarms"]:
-            if alarm["alarmId"] == self.next_alarm_id:
-                routine["override"] = {
-                    "routineEnabled": True,
-                    "alarms": [{
-                        "enabled": enabled,
-                        "disabledIndividually": not enabled,
-                        "settings": alarm["settings"],
-                        "dismissUntil": alarm.get("dismissUntil"),
-                        "snoozeUntil": alarm.get("snoozeUntil"),
-                        "time": alarm["timeWithOffset"]["time"],
-                    }],
-                }
-                await self.device.api_request(
-                    "PUT",
-                    f"{APP_API_URL}v2/users/{self.user_id}/routines/{routine_id}",
-                    data=routine
-                )
-                return
 
-    async def _set_alarm_enabled(self, routine_id: str, alarm_id: str, enabled: bool) -> None:
-        """Enables or disables the alarm with the specified ID."""
-        url = APP_API_URL + f"v2/users/{self.user_id}/routines/{routine_id}"
-        routine = self._get_routine(routine_id)
+        alarm = self._get_alarm(target_id)
+        data = dict(alarm)
+        data["enabled"] = enabled
+        # Remove server-computed fields
+        for key in ("nextTimestamp", "startTimestamp", "endTimestamp",
+                     "dismissedUntil", "snoozedUntil"):
+            data.pop(key, None)
 
-        if "override" in routine:
-            for alarm in routine["override"]["alarms"]:
-                if alarm["alarmId"] == alarm_id:
-                    alarm["enabled"] = enabled
-                    alarm["disabledIndividually"] = not enabled
-                    await self.device.api_request("PUT", url, data=routine)
-                    return
-
-        for alarm in routine["alarms"]:
-            if alarm["alarmId"] == alarm_id:
-                alarm["enabled"] = enabled
-                alarm["disabledIndividually"] = not enabled
-                await self.device.api_request("PUT", url, data=routine)
-                return
-
-        raise ValueError(f"Alarm with ID {alarm_id} not found")
+        url = APP_API_URL + f"v1/users/{self.user_id}/alarms/{target_id}"
+        await self.device.api_request("PUT", url, data=data)
 
     async def turn_off_side(self):
         """Turns off the side of the user"""
@@ -954,78 +906,85 @@ class EightUser:  # pylint: disable=too-many-public-methods
         self.trends = trend_data.get("days", [])
 
     async def update_routines_data(self) -> None:
-        url = APP_API_URL + f"v2/users/{self.user_id}/routines"
+        """Update alarm data from the new /v2/alarms endpoint.
+
+        GET /v2/users/{userId}/alarms
+        Response:
+        {
+            "alarms": [
+                {
+                    "id": "uuid",
+                    "enabled": true,
+                    "time": "07:00:00",
+                    "repeat": {"enabled": true, "weekDays": {"monday": true, ...}},
+                    "thermal": {"enabled": true, "temperature": -10},
+                    "vibration": {"enabled": true, "level": 50, "pattern": "rise", "duration": 300},
+                    "snoozing": false,
+                    "snoozedUntil": null,
+                    "nextTimestamp": "2025-01-15T07:00:00Z",
+                    "startTimestamp": "2025-01-15T06:55:00Z",
+                    "endTimestamp": "2025-01-15T07:30:00Z",
+                    "dismissedUntil": null
+                }
+            ],
+            "recommendedAlarm": { ...same shape as alarm above... }
+        }
+        """
+        url = APP_API_URL + f"v2/users/{self.user_id}/alarms"
         resp = await self.device.api_request("GET", url)
 
-        self.routines = resp["settings"]["routines"]
+        self.alarms = resp.get("alarms", [])
 
-        try:
-            nextTimestamp = resp["state"]["nextAlarm"]["nextTimestamp"]
-        except KeyError:
-            nextTimestamp = None
+        # Determine next alarm from recommendedAlarm
+        recommended = resp.get("recommendedAlarm", {})
+        next_timestamp = recommended.get("nextTimestamp")
+        recommended_id = recommended.get("id", "")
 
-        if not nextTimestamp:
-            self.next_alarm = None
-            self.next_alarm_id = None
-            # Check if there is an upcoming routine with an alarm (which is currently disabled)
-            if "upcomingRoutineId" in resp["state"]:
-                upcoming_routine = self._get_routine(resp["state"]["upcomingRoutineId"])
-                if upcoming_routine.get("override"):
-                    if upcoming_routine["override"].get("alarms"):
-                        self.next_alarm_id = upcoming_routine["override"]["alarms"][0]["alarmId"]
-                elif upcoming_routine.get("alarms"):
-                    self.next_alarm_id = upcoming_routine["alarms"][0]["alarmId"]
+        if next_timestamp and recommended_id and recommended.get("enabled", False):
+            self.next_alarm = self.device.convert_string_to_datetime(next_timestamp)
+            self.next_alarm_id = recommended_id
         else:
-            self.next_alarm = self.device.convert_string_to_datetime(nextTimestamp)
-            self.next_alarm_id = resp["state"]["nextAlarm"]["alarmId"]
+            self.next_alarm = None
+            # Even if no next alarm is scheduled, find the first enabled alarm
+            # so we can still reference it for the switch entity
+            self.next_alarm_id = None
+            for alarm in self.alarms:
+                if alarm.get("enabled", False):
+                    self.next_alarm_id = alarm["id"]
+                    if alarm.get("nextTimestamp"):
+                        self.next_alarm = self.device.convert_string_to_datetime(
+                            alarm["nextTimestamp"]
+                        )
+                    break
+
+    async def set_alarm_time(self, alarm_id: str, alarm_time: str) -> None:
+        """Set the time on an existing alarm via the new alarms API.
+        Sends the full alarm object as required by the API.
+
+        PUT /v1/users/{userId}/alarms/{alarmId}
+        Request: same as set_alarm_enabled, with "time" field updated
+        Response: 200 with updated alarm object
+        """
+        alarm = self._get_alarm(alarm_id)
+        data = dict(alarm)
+        data["time"] = alarm_time
+        for key in ("nextTimestamp", "startTimestamp", "endTimestamp",
+                     "dismissedUntil", "snoozedUntil"):
+            data.pop(key, None)
+
+        url = APP_API_URL + f"v1/users/{self.user_id}/alarms/{alarm_id}"
+        await self.device.api_request("PUT", url, data=data)
 
     async def set_routine_alarm(self, routine_id: str, alarm_id: str, alarm_time: str) -> None:
-        """Set an alarm from a routine."""
-        await self.update_routines_data()
-        # Find the original routine
-        original_routine: dict[str, Any] = {}
-        for r in self.routines:
-            try:
-                if r["id"] == routine_id:
-                    original_routine = r
-            except KeyError:
-                pass
-
-        # Update the alarm
-        try:
-            for a in original_routine["alarms"]:
-                if a["alarmId"] == alarm_id:
-                    a["enabledSince"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-                    a["timeWithOffset"]["time"] = alarm_time
-        except KeyError:
-            pass
-
-        # Push to cloud
-        url = APP_API_URL + f"v2/users/{self.user_id}/routines/{routine_id}"
-        await self.device.api_request("PUT", url, data=original_routine)
+        """Set an alarm time. routine_id is ignored (kept for backward compat)."""
+        await self.set_alarm_time(alarm_id, alarm_time)
 
     async def set_routine_bedtime(self, routine_id: str, bedtime: str) -> None:
-        """Set an alarm from a routine."""
-        await self.update_routines_data()
-        # Find the original routine
-        original_routine: dict[str, Any] = {}
-        for r in self.routines:
-            try:
-                if r["id"] == routine_id:
-                    original_routine = r
-            except KeyError:
-                pass
-
-        # Update bedtime
-        try:
-            original_routine["bedtime"]["time"] = bedtime
-            original_routine["bedtime"]["dayOffset"] = "MinusOne" if "12:00:00" <= bedtime else "Zero"
-        except KeyError:
-            pass
-
-        # Push to cloud
-        url = APP_API_URL + f"v2/users/{self.user_id}/routines/{routine_id}"
-        await self.device.api_request("PUT", url, data=original_routine)
+        """Bedtime routines are no longer supported by the new API."""
+        _LOGGER.warning(
+            "set_routine_bedtime is no longer supported. "
+            "Eight Sleep has migrated away from the routines API."
+        )
 
     async def update_base_data(self):
         """Update the data about the bed base."""
@@ -1083,28 +1042,22 @@ class EightUser:  # pylint: disable=too-many-public-methods
         thermal_enabled: bool = True,
         thermal_level: int = 0,
     ) -> None:
-        """Set a one-off alarm."""
-        url = APP_API_URL + f"v2/users/{self.user_id}/routines?ignoreDeviceErrors=false"
+        """Create a new alarm via the new alarms API."""
+        url = APP_API_URL + f"v1/users/{self.user_id}/alarms"
         data = {
-            "oneOffAlarms": [
-                {
-                    "time": time,
-                    "enabled": enabled,
-                    "settings": {
-                        "vibration": {
-                            "enabled": vibration_enabled,
-                            "powerLevel": vibration_power_level,
-                            "pattern": vibration_pattern,
-                        },
-                        "thermal": {
-                            "enabled": thermal_enabled,
-                            "level": thermal_level,
-                        },
-                    },
-                }
-            ]
+            "time": time,
+            "enabled": enabled,
+            "vibration": {
+                "enabled": vibration_enabled,
+                "powerLevel": vibration_power_level,
+                "pattern": vibration_pattern,
+            },
+            "thermal": {
+                "enabled": thermal_enabled,
+                "level": thermal_level,
+            },
         }
-        await self.device.api_request("PUT", url, data=data)
+        await self.device.api_request("POST", url, data=data)
 
     # Speaker methods
     @property

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -797,16 +797,24 @@ class EightUser:  # pylint: disable=too-many-public-methods
 
     async def alarm_snooze(self, snooze_minutes: int):
         """Snoozes the user alarm for the specified minutes.
+        Silently ignores 409 Conflict (alarm not currently ringing).
 
         PUT /v1/users/{userId}/alarms/{alarmId}/snooze
         Request: {"snoozeMinutes": 9, "ignoreDeviceErrors": false}
         Response: 200 empty body (Content-Length: 0) or 409 if not ringing
         """
         if not self.next_alarm_id:
-            raise Exception(f"No next alarm ID set for {self.user_id}")
+            _LOGGER.debug("No next alarm ID set for %s, nothing to snooze", self.user_id)
+            return
         url = APP_API_URL + f"v1/users/{self.user_id}/alarms/{self.next_alarm_id}/snooze"
         data = {"snoozeMinutes": snooze_minutes, "ignoreDeviceErrors": False}
-        await self.device.api_request("PUT", url, data=data)
+        try:
+            await self.device.api_request("PUT", url, data=data)
+        except RequestError as err:
+            if "409" in str(err):
+                _LOGGER.debug("Alarm not currently ringing for %s, nothing to snooze", self.user_id)
+            else:
+                raise
 
     async def alarm_stop(self):
         """Stops the next user alarm. Uses dismiss endpoint (no separate stop in API)."""
@@ -814,16 +822,24 @@ class EightUser:  # pylint: disable=too-many-public-methods
 
     async def alarm_dismiss(self):
         """Dismisses the next user alarm.
+        Silently ignores 409 Conflict (alarm not currently ringing).
 
         PUT /v1/users/{userId}/alarms/{alarmId}/dismiss
         Request: {"ignoreDeviceErrors": false}
         Response: 200 with alarm object (or 409 if alarm not ringing)
         """
         if not self.next_alarm_id:
-            raise Exception(f"No next alarm ID set for {self.user_id}")
+            _LOGGER.debug("No next alarm ID set for %s, nothing to dismiss", self.user_id)
+            return
         url = APP_API_URL + f"v1/users/{self.user_id}/alarms/{self.next_alarm_id}/dismiss"
         data = {"ignoreDeviceErrors": False}
-        await self.device.api_request("PUT", url, data=data)
+        try:
+            await self.device.api_request("PUT", url, data=data)
+        except RequestError as err:
+            if "409" in str(err):
+                _LOGGER.debug("Alarm not currently ringing for %s, nothing to dismiss", self.user_id)
+            else:
+                raise
 
     async def set_alarm_enabled(self, routine_id: str | None, alarm_id: str | None, enabled: bool) -> None:
         """Enables or disables the alarm.

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -39,6 +39,7 @@ class EightUser:  # pylint: disable=too-many-public-methods
         self.smart_schedule: dict[str, Any] | None = None
         self.next_alarm = None
         self.next_alarm_id = None
+        self.snooze_minutes: int = 9
         self.bed_state_type = None
         self.current_side_temp = None
         self.target_heating_temp = None
@@ -795,21 +796,43 @@ class EightUser:  # pylint: disable=too-many-public-methods
         data = {"currentState": {"type": "smart"}}
         await self.device.api_request("PUT", url, data=data)
 
+    def _is_alarm_active(self) -> bool:
+        """Check if the next alarm is currently ringing or snoozed."""
+        if not self.next_alarm_id:
+            return False
+        try:
+            alarm = self._get_alarm(self.next_alarm_id)
+        except Exception:
+            return False
+        if alarm.get("snoozing", False):
+            return True
+        start = alarm.get("startTimestamp")
+        end = alarm.get("endTimestamp")
+        if not start or not end:
+            return False
+        now = datetime.now(timezone.utc)
+        try:
+            start_dt = datetime.fromisoformat(start.replace("Z", "+00:00"))
+            end_dt = datetime.fromisoformat(end.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return False
+        return start_dt <= now <= end_dt
+
     async def alarm_snooze(self, snooze_minutes: int):
         """Snoozes the user alarm for the specified minutes.
-        Silently ignores 409 Conflict (alarm not currently ringing).
+        Only acts if the alarm is currently ringing or snoozed.
 
         PUT /v1/users/{userId}/alarms/{alarmId}/snooze
         Request: {"snoozeMinutes": 9, "ignoreDeviceErrors": false}
         Response: 200 empty body (Content-Length: 0) or 409 if not ringing
         """
-        if not self.next_alarm_id:
-            _LOGGER.debug("No next alarm ID set for %s, nothing to snooze", self.user_id)
+        if not self._is_alarm_active():
+            _LOGGER.debug("Alarm not currently active for %s, nothing to snooze", self.user_id)
             return
         url = APP_API_URL + f"v1/users/{self.user_id}/alarms/{self.next_alarm_id}/snooze"
         data = {"snoozeMinutes": snooze_minutes, "ignoreDeviceErrors": False}
         try:
-            await self.device.api_request("PUT", url, data=data)
+            await self.device.api_request("PUT", url, data=data, return_json=False)
         except RequestError as err:
             if "409" in str(err):
                 _LOGGER.debug("Alarm not currently ringing for %s, nothing to snooze", self.user_id)

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -355,7 +355,7 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
         if self._sensor == "sleep_stage":
             return self._user_obj.current_sleep_stage
         if self._sensor == "routines":
-            return len(self._user_obj.routines) if self._user_obj.routines else 0
+            return len(self._user_obj.alarms) if self._user_obj.alarms else 0
 
         return None
 
@@ -376,33 +376,20 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
             }
             return state_attr
         elif self._sensor == "routines" and self._user_obj:
-            routines_data = []
-            for routine in self._user_obj.routines:
-                routine_info = {
-                    "id": routine["id"],
-                    "name": routine.get("name", "Unnamed Routine"),
-                    "days": routine.get("days", []),
-                    "alarms": []
-                }
-                # Add alarms from the main routine
-                for alarm in routine.get("alarms", []):
-                    routine_info["alarms"].append({
-                        "id": alarm["alarmId"],
-                        "time": alarm["timeWithOffset"]["time"],
-                        "enabled": alarm["enabled"],
-                        "disabledIndividually": alarm.get("disabledIndividually", False)
-                    })
-                # Add alarms from override if present
-                if "override" in routine:
-                    for alarm in routine["override"].get("alarms", []):
-                        routine_info["alarms"].append({
-                            "id": alarm["alarmId"],
-                            "time": alarm["time"],
-                            "enabled": alarm["enabled"],
-                            "disabledIndividually": not alarm["enabled"]
-                        })
-                routines_data.append(routine_info)
-            return {"routines": routines_data}
+            alarms_data = []
+            for alarm in self._user_obj.alarms:
+                repeat = alarm.get("repeat", {})
+                weekdays = repeat.get("weekDays", {})
+                days = [day.capitalize() for day, active in weekdays.items() if active]
+                alarms_data.append({
+                    "id": alarm["id"],
+                    "time": alarm.get("time"),
+                    "enabled": alarm.get("enabled", False),
+                    "days": days if repeat.get("enabled") else [],
+                    "vibration": alarm.get("vibration", {}),
+                    "thermal": alarm.get("thermal", {}),
+                })
+            return {"alarms": alarms_data}
 
         if attr is None:
             # Skip attributes if sensor type doesn't support

--- a/custom_components/eight_sleep/switch.py
+++ b/custom_components/eight_sleep/switch.py
@@ -148,12 +148,16 @@ class EightSwitchEntity(EightSleepBaseEntity, SwitchEntity):
                     )
                     self._attr_extra_state_attributes["thermal"] = alarm.get("thermal", {})
                     self._attr_extra_state_attributes["vibration"] = alarm.get("vibration", {})
+                    self._attr_extra_state_attributes["snoozing"] = alarm.get("snoozing", False)
+                    self._attr_extra_state_attributes["snoozed_until"] = alarm.get("snoozedUntil")
                     return
 
         self._attr_extra_state_attributes.pop("time", None)
         self._attr_extra_state_attributes.pop("days", None)
         self._attr_extra_state_attributes.pop("thermal", None)
         self._attr_extra_state_attributes.pop("vibration", None)
+        self._attr_extra_state_attributes.pop("snoozing", None)
+        self._attr_extra_state_attributes.pop("snoozed_until", None)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         if self._user_obj:

--- a/custom_components/eight_sleep/switch.py
+++ b/custom_components/eight_sleep/switch.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import logging
 from typing import Any
 
 from custom_components.eight_sleep.pyEight.user import EightUser
@@ -8,11 +9,14 @@ from .pyEight.eight import EightSleep
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import EightSleepBaseEntity, EightSleepConfigEntryData
 from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _format_weekdays(repeat: dict) -> str | list[str]:
@@ -28,32 +32,88 @@ def _format_weekdays(repeat: dict) -> str | list[str]:
     return day_names
 
 
+def _make_alarm_key(alarm_id: str) -> str:
+    """Build a stable entity key from an alarm's UUID."""
+    return f"alarm_{alarm_id}"
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     config_entry_data: EightSleepConfigEntryData = hass.data[DOMAIN][entry.entry_id]
     eight = config_entry_data.api
+    coordinator = config_entry_data.user_coordinator
 
-    entities: list[SwitchEntity] = []
+    # Track entities per user keyed by alarm_id for dynamic add/remove
+    tracked: dict[str, dict[str, EightSwitchEntity]] = {}
 
     for user in eight.users.values():
-        # Create a switch entity for each alarm from the new alarms API
-        for alarm_index, alarm in enumerate(user.alarms, start=1):
-            description = SwitchEntityDescription(
-                key=f"alarm_{alarm_index}",
-                name=f"Alarm {alarm_index}",
-                icon="mdi:alarm",
-            )
+        user_entities: dict[str, EightSwitchEntity] = {}
+        for index, alarm in enumerate(user.alarms, start=1):
+            entity = _create_alarm_entity(entry, coordinator, eight, user, alarm, index)
+            user_entities[alarm["id"]] = entity
+        tracked[user.user_id] = user_entities
 
-            entities.append(EightSwitchEntity(
-                entry,
-                config_entry_data.user_coordinator,
-                eight,
-                user,
-                description,
-                alarm["id"]))
+    # Add all initial entities
+    all_entities = [e for user_map in tracked.values() for e in user_map.values()]
+    async_add_entities(all_entities)
 
-    async_add_entities(entities)
+    # Register a listener to dynamically add/remove entities on coordinator refresh
+    @callback
+    def _async_sync_alarm_entities() -> None:
+        ent_reg = er.async_get(hass)
+
+        for user in eight.users.values():
+            user_entities = tracked.setdefault(user.user_id, {})
+            current_ids = {alarm["id"] for alarm in user.alarms}
+            tracked_ids = set(user_entities.keys())
+
+            # Add entities for new alarms
+            new_ids = current_ids - tracked_ids
+            if new_ids:
+                next_index = len(user_entities) + 1
+                new_entities = []
+                for alarm in user.alarms:
+                    if alarm["id"] in new_ids:
+                        entity = _create_alarm_entity(
+                            entry, coordinator, eight, user, alarm, next_index
+                        )
+                        next_index += 1
+                        user_entities[alarm["id"]] = entity
+                        new_entities.append(entity)
+                async_add_entities(new_entities)
+                _LOGGER.debug("Added %d new alarm entities for user %s", len(new_entities), user.user_id)
+
+            # Remove entities for deleted alarms
+            removed_ids = tracked_ids - current_ids
+            for alarm_id in removed_ids:
+                entity = user_entities.pop(alarm_id)
+                entity_id = ent_reg.async_get_entity_id(
+                    "switch", DOMAIN, entity.unique_id
+                )
+                if entity_id:
+                    ent_reg.async_remove(entity_id)
+                    _LOGGER.debug("Removed alarm entity %s for user %s", entity_id, user.user_id)
+
+    coordinator.async_add_listener(_async_sync_alarm_entities)
+
+
+def _create_alarm_entity(
+    entry: ConfigEntry,
+    coordinator: DataUpdateCoordinator,
+    eight: EightSleep,
+    user: EightUser,
+    alarm: dict[str, Any],
+    index: int,
+) -> EightSwitchEntity:
+    """Create a switch entity for a single alarm."""
+    alarm_id = alarm["id"]
+    description = SwitchEntityDescription(
+        key=_make_alarm_key(alarm_id),
+        name=f"Alarm {index}",
+        icon="mdi:alarm",
+    )
+    return EightSwitchEntity(entry, coordinator, eight, user, description, alarm_id)
 
 
 class EightSwitchEntity(EightSleepBaseEntity, SwitchEntity):
@@ -66,11 +126,13 @@ class EightSwitchEntity(EightSleepBaseEntity, SwitchEntity):
         eight: EightSleep,
         user: EightUser,
         entity_description: SwitchEntityDescription,
-        alarm_id: str | None = None,
+        alarm_id: str,
     ) -> None:
         super().__init__(entry, coordinator, eight, user, entity_description.key)
         self.entity_description = entity_description
         self._alarm_id = alarm_id
+        # Set clean positional name for entity_id generation at registration
+        self._attr_name = entity_description.name
         self._attr_extra_state_attributes = {}
         self._update_attributes()
 
@@ -80,13 +142,13 @@ class EightSwitchEntity(EightSleepBaseEntity, SwitchEntity):
 
             for alarm in self._user_obj.alarms:
                 if alarm["id"] == self._alarm_id:
-                        self._attr_extra_state_attributes["time"] = alarm.get("time")
-                        self._attr_extra_state_attributes["days"] = _format_weekdays(
-                            alarm.get("repeat", {})
-                        )
-                        self._attr_extra_state_attributes["thermal"] = alarm.get("thermal", {})
-                        self._attr_extra_state_attributes["vibration"] = alarm.get("vibration", {})
-                        return
+                    self._attr_extra_state_attributes["time"] = alarm.get("time")
+                    self._attr_extra_state_attributes["days"] = _format_weekdays(
+                        alarm.get("repeat", {})
+                    )
+                    self._attr_extra_state_attributes["thermal"] = alarm.get("thermal", {})
+                    self._attr_extra_state_attributes["vibration"] = alarm.get("vibration", {})
+                    return
 
         self._attr_extra_state_attributes.pop("time", None)
         self._attr_extra_state_attributes.pop("days", None)
@@ -106,4 +168,12 @@ class EightSwitchEntity(EightSleepBaseEntity, SwitchEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         self._update_attributes()
+        # Update display name dynamically (entity_id is already locked at registration)
+        if self._user_obj:
+            for alarm in self._user_obj.alarms:
+                if alarm["id"] == self._alarm_id:
+                    alarm_time = alarm.get("time", "")
+                    if alarm_time:
+                        self._attr_name = f"Alarm {alarm_time[:5]}"
+                    break
         super()._handle_coordinator_update()

--- a/custom_components/eight_sleep/switch.py
+++ b/custom_components/eight_sleep/switch.py
@@ -15,6 +15,19 @@ from . import EightSleepBaseEntity, EightSleepConfigEntryData
 from .const import DOMAIN
 
 
+def _format_weekdays(repeat: dict) -> str | list[str]:
+    """Convert the new repeat.weekDays dict to a display-friendly format."""
+    if not repeat.get("enabled", False):
+        return "Once"
+    weekdays = repeat.get("weekDays", {})
+    day_names = [day.capitalize() for day, active in weekdays.items() if active]
+    if len(day_names) == 7:
+        return "Every day"
+    if not day_names:
+        return "Once"
+    return day_names
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
@@ -24,37 +37,21 @@ async def async_setup_entry(
     entities: list[SwitchEntity] = []
 
     for user in eight.users.values():
-        alarm_index = 1
-        for routine in user.routines:
-            for alarm in routine["alarms"]:
-                description = SwitchEntityDescription(
-                    key=f"alarm_{alarm_index}",
-                    name=f"Alarm {alarm_index}",
-                    icon="mdi:alarm",
-                )
+        # Create a switch entity for each alarm from the new alarms API
+        for alarm_index, alarm in enumerate(user.alarms, start=1):
+            description = SwitchEntityDescription(
+                key=f"alarm_{alarm_index}",
+                name=f"Alarm {alarm_index}",
+                icon="mdi:alarm",
+            )
 
-                entities.append(EightSwitchEntity(
-                    entry,
-                    config_entry_data.user_coordinator,
-                    eight,
-                    user,
-                    description,
-                    alarm["alarmId"],
-                    routine["id"]))
-
-                alarm_index += 1
-        description = SwitchEntityDescription(
-            key="next_alarm",
-            name="Next Alarm",
-            icon="mdi:alarm",
-        )
-
-        entities.append(EightSwitchEntity(
-            entry,
-            config_entry_data.user_coordinator,
-            eight,
-            user,
-            description))
+            entities.append(EightSwitchEntity(
+                entry,
+                config_entry_data.user_coordinator,
+                eight,
+                user,
+                description,
+                alarm["id"]))
 
     async_add_entities(entities)
 
@@ -70,12 +67,10 @@ class EightSwitchEntity(EightSleepBaseEntity, SwitchEntity):
         user: EightUser,
         entity_description: SwitchEntityDescription,
         alarm_id: str | None = None,
-        routine_id: str | None = None,
     ) -> None:
         super().__init__(entry, coordinator, eight, user, entity_description.key)
         self.entity_description = entity_description
         self._alarm_id = alarm_id
-        self._routine_id = routine_id
         self._attr_extra_state_attributes = {}
         self._update_attributes()
 
@@ -83,25 +78,15 @@ class EightSwitchEntity(EightSleepBaseEntity, SwitchEntity):
         if self._user_obj:
             self._attr_is_on = self._user_obj.get_alarm_enabled(self._alarm_id)
 
-            alarm_id = self._alarm_id or self._user_obj.next_alarm_id
-            if alarm_id:
-                for routine in self._user_obj.routines:
-                    if "override" in routine:
-                        for alarm in routine["override"]["alarms"]:
-                            if alarm["alarmId"] == alarm_id:
-                                self._attr_extra_state_attributes["time"] = alarm["time"]
-                                self._attr_extra_state_attributes["days"] = "Tonight"
-                                self._attr_extra_state_attributes["thermal"] = alarm["settings"]["thermal"]
-                                self._attr_extra_state_attributes["vibration"] = alarm["settings"]["vibration"]
-                                return
-
-                    for alarm in routine["alarms"]:
-                        if alarm["alarmId"] == alarm_id:
-                            self._attr_extra_state_attributes["time"] = alarm["timeWithOffset"]["time"]
-                            self._attr_extra_state_attributes["days"] = routine["days"]
-                            self._attr_extra_state_attributes["thermal"] = alarm["settings"]["thermal"]
-                            self._attr_extra_state_attributes["vibration"] = alarm["settings"]["vibration"]
-                            return
+            for alarm in self._user_obj.alarms:
+                if alarm["id"] == self._alarm_id:
+                        self._attr_extra_state_attributes["time"] = alarm.get("time")
+                        self._attr_extra_state_attributes["days"] = _format_weekdays(
+                            alarm.get("repeat", {})
+                        )
+                        self._attr_extra_state_attributes["thermal"] = alarm.get("thermal", {})
+                        self._attr_extra_state_attributes["vibration"] = alarm.get("vibration", {})
+                        return
 
         self._attr_extra_state_attributes.pop("time", None)
         self._attr_extra_state_attributes.pop("days", None)
@@ -110,12 +95,12 @@ class EightSwitchEntity(EightSleepBaseEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         if self._user_obj:
-            await self._user_obj.set_alarm_enabled(self._routine_id, self._alarm_id, True)
+            await self._user_obj.set_alarm_enabled(None, self._alarm_id, True)
             await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         if self._user_obj:
-            await self._user_obj.set_alarm_enabled(self._routine_id, self._alarm_id, False)
+            await self._user_obj.set_alarm_enabled(None, self._alarm_id, False)
             await self.coordinator.async_request_refresh()
 
     @callback


### PR DESCRIPTION
## Summary

- **Migrate alarm system from deprecated routines API to dedicated alarms API** (fixes #88). The old `/routines` endpoint no longer returns alarm data; the new `/v2/users/{id}/alarms` and `/v1/users/{id}/alarms/{id}` endpoints are used instead, based on iOS app traffic analysis via MITM proxy.
- **Dynamic alarm switch entities** — alarm switches are now automatically added/removed when alarms are created or deleted in the Eight Sleep app, without requiring an integration reload. Entity identity uses the alarm UUID (stable across reordering) while the entity_id uses a clean positional name (`alarm_1`, `alarm_2`).
- **Dismiss and Snooze alarm buttons** — new button entities for dismissing or snoozing the currently ringing alarm. Both gracefully handle 409 Conflict (alarm not ringing) making them safe for automation (e.g. Zigbee physical buttons).
- **Configurable snooze duration** — new number entity (slider, 5-30 min, default 9) to set snooze length. Includes a client-side `_is_alarm_active()` guard to prevent snooze from firing when no alarm is ringing (the snooze API silently accepts and shifts the alarm time forward otherwise).
- **Alarm switch attributes** — each alarm switch exposes `time`, `days`, `thermal`, `vibration`, `snoozing`, and `snoozed_until` as extra state attributes.

<img width="337" height="445" alt="Screenshot 2026-03-27 at 1 12 57 PM" src="https://github.com/user-attachments/assets/f8af0366-03e3-4cf3-a9e0-0b8f3ef22680" />


### API endpoints discovered via iOS app MITM proxy

| Action | Method | Endpoint |
|--------|--------|----------|
| List alarms | GET | `/v2/users/{id}/alarms` |
| Update alarm | PUT | `/v1/users/{id}/alarms/{id}` (full object) |
| Dismiss | PUT | `/v1/users/{id}/alarms/{id}/dismiss` |
| Snooze | PUT | `/v1/users/{id}/alarms/{id}/snooze` |

### Files changed
- `pyEight/user.py` — rewrote alarm methods for new API, added `_is_alarm_active()` guard
- `switch.py` — dynamic entity management with UUID-based identity
- `button.py` — new file, dismiss & snooze buttons
- `number.py` — added snooze minutes slider, made `base_entity` configurable
- `__init__.py` — added `Platform.BUTTON`
- `sensor.py` — updated routines sensor for new alarm structure

## Test plan
- [x] Load integration, verify alarm switches appear with correct on/off state
- [x] Toggle alarm switch, verify it enables/disables the alarm via API
- [x] Create a new alarm in the Eight Sleep app, wait for coordinator refresh (~30s), verify new switch appears without reload
- [x] Delete an alarm in the app, verify switch is removed
- [x] Press Dismiss Alarm while alarm is ringing — alarm stops
- [x] Press Dismiss Alarm while no alarm is ringing — no error, silently ignored
- [x] Set snooze minutes slider, press Snooze Alarm while ringing — alarm snoozes for configured duration
- [x] Press Snooze Alarm while no alarm is ringing — no error, silently ignored
- [x] Verify alarm switch attributes (`time`, `days`, `snoozing`, `snoozed_until`) update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code). Tested the changes on my local HA install with multiple accounts (2 hubs) and multiple sides.
