### PR TITLE
Fix alarm dismiss race, one-off alarm detection, and coordinator cascade

### DIFF
--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -251,9 +251,21 @@ class EightSleep:
         )
 
     async def update_user_data(self) -> None:
-        """Update data for users."""
+        """Update data for users.
+
+        Each user is updated independently so that a transient API failure
+        for one user (e.g. 504, 500) does not abort the entire coordinator
+        update and silently freeze listeners for all users.
+        """
         for user in self.users.values():
-            await user.update_user()
+            try:
+                await user.update_user()
+            except Exception as err:
+                _LOGGER.warning(
+                    "Failed to update user %s: %s — continuing with other users",
+                    user.user_id,
+                    err,
+                )
 
     async def update_base_data(self) -> None:
         """Update data for the bed base.

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -869,24 +869,32 @@ class EightUser:  # pylint: disable=too-many-public-methods
         """Stops the next user alarm. Uses dismiss endpoint (no separate stop in API)."""
         await self.alarm_dismiss()
 
-    async def alarm_dismiss(self):
-        """Dismisses the next user alarm.
-        Silently ignores 409 Conflict (alarm not currently ringing).
+    async def alarm_dismiss(self, alarm_id: str | None = None) -> bool:
+        """Dismisses the specified alarm (or next alarm if not specified).
+        Returns True if dismissed successfully, False if not ringing (409).
+
+        Accepts an explicit alarm_id to avoid a race condition where
+        self.next_alarm_id could change between the caller's decision to
+        dismiss and the actual API call (e.g. the coordinator refreshes
+        and flips to tomorrow's alarm mid-dismiss).
 
         PUT /v1/users/{userId}/alarms/{alarmId}/dismiss
         Request: {"ignoreDeviceErrors": false}
         Response: 200 with alarm object (or 409 if alarm not ringing)
         """
-        if not self.next_alarm_id:
-            _LOGGER.debug("No next alarm ID set for %s, nothing to dismiss", self.user_id)
-            return
-        url = APP_API_URL + f"v1/users/{self.user_id}/alarms/{self.next_alarm_id}/dismiss"
+        target_id = alarm_id or self.next_alarm_id
+        if not target_id:
+            _LOGGER.debug("No alarm ID to dismiss for %s", self.user_id)
+            return False
+        url = APP_API_URL + f"v1/users/{self.user_id}/alarms/{target_id}/dismiss"
         data = {"ignoreDeviceErrors": False}
         try:
             await self.device.api_request("PUT", url, data=data)
+            return True
         except RequestError as err:
             if "409" in str(err):
                 _LOGGER.debug("Alarm not currently ringing for %s, nothing to dismiss", self.user_id)
+                return False
             else:
                 raise
 
@@ -1000,27 +1008,50 @@ class EightUser:  # pylint: disable=too-many-public-methods
 
         self.alarms = resp.get("alarms", [])
 
-        # Determine next alarm from recommendedAlarm
-        recommended = resp.get("recommendedAlarm", {})
-        next_timestamp = recommended.get("nextTimestamp")
-        recommended_id = recommended.get("id", "")
+        # Find the chronologically soonest enabled alarm across ALL alarms
+        # (not just recommendedAlarm, which may skip one-off alarms).
+        #
+        # An alarm is still "current" if its endTimestamp hasn't passed yet
+        # (i.e. it is still ringing). This prevents the next_alarm from
+        # flipping to tomorrow's alarm the instant now >= nextTimestamp,
+        # which would cause the dismiss button to target the wrong alarm.
+        now = datetime.now(timezone.utc)
+        soonest_time: datetime | None = None
+        soonest_id: str | None = None
 
-        if next_timestamp and recommended_id and recommended.get("enabled", False):
-            self.next_alarm = self.device.convert_string_to_datetime(next_timestamp)
-            self.next_alarm_id = recommended_id
+        all_candidates = list(self.alarms)
+        recommended = resp.get("recommendedAlarm", {})
+        if recommended.get("id"):
+            all_candidates.append(recommended)
+
+        for alarm in all_candidates:
+            if not alarm.get("enabled", False):
+                continue
+            next_ts = alarm.get("nextTimestamp")
+            if not next_ts:
+                continue
+            alarm_dt = self.device.convert_string_to_datetime(next_ts)
+
+            # An alarm is still relevant if it hasn't ended yet (still ringing)
+            # or if its nextTimestamp is in the future (upcoming).
+            end_ts = alarm.get("endTimestamp")
+            if end_ts:
+                end_dt = self.device.convert_string_to_datetime(end_ts)
+                if end_dt < now:
+                    continue  # alarm fully ended
+            elif alarm_dt < now:
+                continue  # no endTimestamp, skip if past
+
+            if soonest_time is None or alarm_dt < soonest_time:
+                soonest_time = alarm_dt
+                soonest_id = alarm["id"]
+
+        if soonest_time and soonest_id:
+            self.next_alarm = soonest_time
+            self.next_alarm_id = soonest_id
         else:
             self.next_alarm = None
-            # Even if no next alarm is scheduled, find the first enabled alarm
-            # so we can still reference it for the switch entity
             self.next_alarm_id = None
-            for alarm in self.alarms:
-                if alarm.get("enabled", False):
-                    self.next_alarm_id = alarm["id"]
-                    if alarm.get("nextTimestamp"):
-                        self.next_alarm = self.device.convert_string_to_datetime(
-                            alarm["nextTimestamp"]
-                        )
-                    break
 
     async def set_alarm_time(self, alarm_id: str, alarm_time: str) -> None:
         """Set the time on an existing alarm via the new alarms API.


### PR DESCRIPTION
## Summary

Three independent bug fixes for the alarm system, discovered while building a "skip alarm if empty" feature that depends on reliable alarm dismiss + detection:

- **Coordinator cascade isolation** (`update_user_data`): wrap each user's update in `try/except` so a transient API failure (504, 500) for one user does not abort the entire coordinator update and silently freeze listeners for all other users. Latent since multi-pod support (PR #109). Confirmed in production: saw `Failed to update user ... — continuing with other users` correctly isolating failures overnight.

- **`alarm_dismiss` race condition**: accept an explicit `alarm_id` parameter and return `bool` indicating success. Fixes a race where `self.next_alarm_id` changes between the caller's decision to dismiss and the actual API call (e.g. coordinator refreshes mid-dismiss and flips to tomorrow's alarm). Backward compatible — existing callers that pass no argument still target `self.next_alarm_id`.

- **`update_routines_data` one-off alarm detection**: scan ALL enabled alarms (not just `recommendedAlarm`) to find the chronologically soonest one. Fixes one-off alarms not being surfaced as `next_alarm`. Also uses `endTimestamp` to keep a currently-ringing alarm as "current" instead of flipping to tomorrow's alarm once `now >= nextTimestamp`, which caused the dismiss button to target the wrong alarm mid-ring.

## Test plan

- [x] Cascade fix: verified in production overnight — 4 transient API failures (500/504) correctly isolated, other users unaffected
- [x] alarm_dismiss: tested with one-off alarm dismiss via HA automation and manual button press
- [x] update_routines_data: tested with one-off alarms set 10 minutes in the future, confirmed correct `next_alarm_id` surfacing and dismiss targeting
- [x] Backward compatibility: existing `alarm_stop()` calls `alarm_dismiss()` with no args — still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)