### PR TITLE
Add pillow temperature support

### DIFF
--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -334,6 +334,12 @@ class EightSleepBaseEntity(CoordinatorEntity[DataUpdateCoordinator]):
             lambda: self._user_obj.increment_heating_level(target)
         )
 
+    async def async_pillow_increment(self, target: int) -> None:
+        """Handle eight sleep pillow increment calls."""
+        await self._generic_service_call(
+            lambda: self._user_obj.increment_pillow_heating_level(target)
+        )
+
     async def async_side_off(
         self,
     ) -> None:

--- a/custom_components/eight_sleep/climate.py
+++ b/custom_components/eight_sleep/climate.py
@@ -59,6 +59,20 @@ async def async_setup_entry(
         for user in eight.users.values()
     ]
 
+    # Add pillow climate entities for users with pillows
+    for user in eight.users.values():
+        if user.has_pillow:
+            entities.append(
+                EightPillowThermostat(
+                    entry,
+                    config_entry_data.user_coordinator,
+                    eight,
+                    user,
+                    "pillow_climate",
+                    hass,
+                )
+            )
+
     async_add_entities(entities)
 
 
@@ -263,4 +277,148 @@ class EightSleepThermostat(EightSleepBaseEntity, ClimateEntity, RestoreEntity):
         await self._user_obj.set_heating_level(level, DEFAULT_DURATION)
         await self._eight.update_device_data()
         # Refresh state
+        await self.coordinator.async_refresh()
+
+
+class EightPillowThermostat(EightSleepBaseEntity, ClimateEntity, RestoreEntity):
+    """Representation of an Eight Sleep Pillow Thermostat device."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Pillow Climate"
+    _attr_hvac_modes = [HVACMode.HEAT_COOL, HVACMode.OFF]
+    _attr_target_temperature_step = TEMP_STEP
+    _attr_supported_features = (
+        ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TARGET_TEMPERATURE
+    )
+    _enable_turn_on_off_backwards_compatibility = False
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: DataUpdateCoordinator,
+        eight: EightSleep,
+        user: EightUser,
+        sensor: str,
+        hass: HomeAssistant,
+    ) -> None:
+        """Initialize the pillow thermostat."""
+        super().__init__(entry, coordinator, eight, user, sensor)
+        self._attr_temperature_unit = hass.config.units.temperature_unit
+        if self._attr_temperature_unit == UnitOfTemperature.CELSIUS:
+            self._attr_min_temp = MIN_TEMP_C
+            self._attr_max_temp = MAX_TEMP_C
+        else:
+            self._attr_min_temp = MIN_TEMP_F
+            self._attr_max_temp = MAX_TEMP_F
+
+        # Initialize target temperature from pillow data if on
+        if user.pillow_state and user.pillow_state != "off":
+            level = user.pillow_current_level
+            if level is not None:
+                unit = convert_hass_temp_unit_to_pyeight_temp_unit(self.temperature_unit)
+                self._attr_target_temperature = heating_level_to_temp(level, unit)
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity added to Home Assistant and restore previous temperature."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state:
+            temp = last_state.attributes.get(ATTR_TEMPERATURE)
+            if temp is not None:
+                try:
+                    self._attr_target_temperature = float(temp)
+                except (ValueError, TypeError):
+                    pass
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current pillow temperature."""
+        if not self._user_obj:
+            return None
+        return self._user_obj.pillow_current_temp
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        """Return current operation mode."""
+        if self._user_obj and self._user_obj.pillow_state and self._user_obj.pillow_state != "off":
+            return HVACMode.HEAT_COOL
+        return HVACMode.OFF
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current running hvac operation."""
+        if not self._user_obj:
+            return None
+
+        state = self._user_obj.pillow_state
+        if not state or state == "off":
+            return HVACAction.OFF
+
+        # Pillow doesn't have separate heating/cooling indicators, show as idle when on
+        return HVACAction.IDLE
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the temperature we try to reach."""
+        if self.hvac_mode == HVACMode.OFF:
+            return self._attr_target_temperature
+
+        if self._user_obj:
+            level = self._user_obj.pillow_current_level
+            if level is not None:
+                unit = convert_hass_temp_unit_to_pyeight_temp_unit(self.temperature_unit)
+                return heating_level_to_temp(level, unit)
+        return self._attr_target_temperature
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if self.hvac_mode != HVACMode.OFF and self._user_obj:
+            level = self._user_obj.pillow_current_level
+            if level is not None:
+                unit = convert_hass_temp_unit_to_pyeight_temp_unit(self.temperature_unit)
+                new_target = heating_level_to_temp(level, unit)
+                if self._attr_target_temperature != new_target:
+                    self._attr_target_temperature = new_target
+        super()._handle_coordinator_update()
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set HVAC mode (heat_cool or off)."""
+        if not self._user_obj:
+            return
+
+        if hvac_mode == HVACMode.OFF:
+            await self._user_obj.turn_off_pillow()
+        else:
+            await self._user_obj.turn_on_pillow()
+            if self._attr_target_temperature is not None:
+                await self.async_set_temperature(temperature=self._attr_target_temperature)
+
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set new target temperature."""
+        if not self._user_obj:
+            return
+
+        if ATTR_TEMPERATURE not in kwargs:
+            return
+
+        temperature = kwargs[ATTR_TEMPERATURE]
+        if temperature < self.min_temp or temperature > self.max_temp:
+            _LOGGER.warning(
+                "Pillow temperature %s out of range (min: %s, max: %s)",
+                temperature,
+                self.min_temp,
+                self.max_temp,
+            )
+            return
+
+        self._attr_target_temperature = temperature
+
+        unit = convert_hass_temp_unit_to_pyeight_temp_unit(self.temperature_unit)
+        level = temp_to_heating_level(temperature, unit)
+
+        await self._user_obj.set_pillow_heating_level(level)
         await self.coordinator.async_refresh()

--- a/custom_components/eight_sleep/const.py
+++ b/custom_components/eight_sleep/const.py
@@ -67,6 +67,7 @@ SERVICE_AWAY_MODE_START = "away_mode_start"
 SERVICE_AWAY_MODE_STOP = "away_mode_stop"
 SERVICE_REFRESH_DATA = "refresh_data"
 SERVICE_SET_ONE_OFF_ALARM = "set_one_off_alarm"
+SERVICE_PILLOW_INCREMENT = "pillow_increment"
 
 ATTR_TARGET = "target"
 ATTR_DURATION = "duration"

--- a/custom_components/eight_sleep/number.py
+++ b/custom_components/eight_sleep/number.py
@@ -41,6 +41,15 @@ SNOOZE_MINUTES_DESCRIPTION = NumberEntityDescription(
     icon="mdi:alarm-snooze",
 )
 
+PILLOW_LEVEL_DESCRIPTION = NumberEntityDescription(
+    key="pillow_level",
+    native_max_value=100,
+    native_min_value=-100,
+    native_step=5,
+    name="Pillow Level",
+    icon="mdi:pillow",
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -65,6 +74,17 @@ async def async_setup_entry(
                 base_entity=False,
             )
         )
+
+        # Add pillow level number entity if user has a pillow
+        if user.has_pillow:
+            entities.append(
+                EightPillowNumberEntity(
+                    entry,
+                    config_entry_data.user_coordinator,
+                    eight,
+                    user,
+                )
+            )
 
     user = eight.base_user
     if user:
@@ -132,3 +152,28 @@ class EightNumberEntity(EightSleepBaseEntity, NumberEntity, RestoreEntity):
     async def async_set_native_value(self, value: float) -> None:
         self._set_value_callback(value)
         self.schedule_update_ha_state()
+
+
+class EightPillowNumberEntity(EightSleepBaseEntity, NumberEntity):
+    """Number entity for controlling pillow temperature level."""
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: DataUpdateCoordinator,
+        eight: EightSleep,
+        user: EightUser,
+    ):
+        super().__init__(entry, coordinator, eight, user, PILLOW_LEVEL_DESCRIPTION.key, base_entity=False)
+        self.entity_description = PILLOW_LEVEL_DESCRIPTION
+
+    @property
+    def native_value(self) -> float | None:
+        if self._user_obj and self._user_obj.has_pillow:
+            return self._user_obj.pillow_current_level
+        return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        if self._user_obj and self._user_obj.has_pillow:
+            await self._user_obj.set_pillow_heating_level(int(value))
+            await self.coordinator.async_request_refresh()

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -49,11 +49,12 @@ class EightUser:  # pylint: disable=too-many-public-methods
         # Pillow data
         self._pillow_data: dict[str, Any] | None = None
         self._pillow_device_id: str | None = None
+        self._has_pillow_device: bool = False  # Persistent flag, doesn't reset on API errors
 
     @property
     def has_pillow(self) -> bool:
         """Return True if user has a pillow device."""
-        return self._pillow_data is not None
+        return self._has_pillow_device
 
     @property
     def pillow_current_level(self) -> int | None:
@@ -797,6 +798,7 @@ class EightUser:  # pylint: disable=too-many-public-methods
 
                     if specialization == "pillow":
                         self._pillow_device_id = device_info.get("deviceId")
+                        self._has_pillow_device = True  # Set persistent flag
                         self._pillow_data = {
                             "currentLevel": device_data.get("currentLevel"),
                             "currentDeviceLevel": device_data.get("currentDeviceLevel"),
@@ -902,10 +904,6 @@ class EightUser:  # pylint: disable=too-many-public-methods
     # Pillow control methods
     async def set_pillow_heating_level(self, level: int) -> None:
         """Set pillow temperature level (-100 to 100)."""
-        if not self._pillow_data:
-            _LOGGER.warning(f"User {self.user_id} has no pillow device")
-            return
-
         # Clamp level to valid range
         level = max(-100, min(100, level))
 
@@ -914,12 +912,19 @@ class EightUser:  # pylint: disable=too-many-public-methods
         await self.device.api_request("PUT", url, data=data)
         _LOGGER.debug(f"User {self.user_id}: Set pillow level to {level}")
 
+    async def increment_pillow_heating_level(self, offset: int) -> None:
+        """Increment pillow heating level by offset."""
+        current_level = 0
+        if self._pillow_data:
+            current_level = self._pillow_data.get("currentLevel", 0) or 0
+        new_level = current_level + offset
+        # Clamp to valid range
+        new_level = max(-100, min(100, new_level))
+
+        await self.set_pillow_heating_level(new_level)
+
     async def turn_on_pillow(self) -> None:
         """Turn on the pillow (smart mode)."""
-        if not self._pillow_data:
-            _LOGGER.warning(f"User {self.user_id} has no pillow device")
-            return
-
         url = APP_API_URL + f"v1/users/{self.user_id}/temperature/pillow?ignoreDeviceErrors=false"
         data = {"currentState": {"type": "smart"}}
         await self.device.api_request("PUT", url, data=data)
@@ -927,10 +932,6 @@ class EightUser:  # pylint: disable=too-many-public-methods
 
     async def turn_off_pillow(self) -> None:
         """Turn off the pillow."""
-        if not self._pillow_data:
-            _LOGGER.warning(f"User {self.user_id} has no pillow device")
-            return
-
         url = APP_API_URL + f"v1/users/{self.user_id}/temperature/pillow?ignoreDeviceErrors=false"
         data = {"currentState": {"type": "off"}}
         await self.device.api_request("PUT", url, data=data)

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -46,6 +46,62 @@ class EightUser:  # pylint: disable=too-many-public-methods
         self._player_state: dict | None = None
         self._audio_tracks: list[dict] = []
 
+        # Pillow data
+        self._pillow_data: dict[str, Any] | None = None
+        self._pillow_device_id: str | None = None
+
+    @property
+    def has_pillow(self) -> bool:
+        """Return True if user has a pillow device."""
+        return self._pillow_data is not None
+
+    @property
+    def pillow_current_level(self) -> int | None:
+        """Return the current pillow temperature level (-100 to 100)."""
+        if not self._pillow_data:
+            return None
+        return self._pillow_data.get("currentLevel")
+
+    @property
+    def pillow_current_device_level(self) -> int | None:
+        """Return the current pillow device temperature level."""
+        if not self._pillow_data:
+            return None
+        return self._pillow_data.get("currentDeviceLevel")
+
+    @property
+    def pillow_current_temp(self) -> float | None:
+        """Return the current pillow temperature in Celsius."""
+        level = self.pillow_current_device_level
+        if level is None:
+            return None
+        return heating_level_to_temp(level, "c")
+
+    @property
+    def pillow_target_temp(self) -> float | None:
+        """Return the pillow target temperature (what it's set to)."""
+        if not self._pillow_data:
+            return None
+        level = self._pillow_data.get("currentLevel")
+        if level is None:
+            return None
+        return heating_level_to_temp(level, "c")
+
+    @property
+    def pillow_state(self) -> str | None:
+        """Return the current pillow state (on/off/smart)."""
+        if not self._pillow_data:
+            return None
+        current_state = self._pillow_data.get("currentState", {})
+        return current_state.get("type")
+
+    @property
+    def pillow_smart_schedule(self) -> dict[str, Any] | None:
+        """Return the pillow smart schedule settings."""
+        if not self._pillow_data:
+            return None
+        return self._pillow_data.get("smart")
+
     def get_autopilot_target_temp(self, unit: str = "c") -> float | None:
         """Return the temperature that Autopilot (smart schedule) is currently targeting."""
         if not self.smart_schedule:
@@ -717,13 +773,47 @@ class EightUser:  # pylint: disable=too-many-public-methods
                     self.current_side_temp = heating_level_to_temp(int(level), "c")
                 else:
                     self.current_side_temp = None
-                
+
                 # Update smart schedule (Autopilot)
                 self.smart_schedule = resp.get("smart")
                 _LOGGER.debug(f"User {self.user_id} Smart Schedule: {self.smart_schedule}")
 
         except Exception as e:
             _LOGGER.warning(f"Error fetching temperature data for {self.user_id}: {e}")
+
+        # Fetch pillow data from /temperature/all endpoint
+        await self._update_pillow_data()
+
+    async def _update_pillow_data(self) -> None:
+        """Fetch pillow temperature data from the /temperature/all endpoint."""
+        url = APP_API_URL + f"v1/users/{self.user_id}/temperature/all"
+        try:
+            resp = await self.device.api_request("GET", url)
+            if resp and isinstance(resp, dict):
+                devices = resp.get("devices", [])
+                for device_data in devices:
+                    device_info = device_data.get("device", {})
+                    specialization = device_info.get("specialization", "")
+
+                    if specialization == "pillow":
+                        self._pillow_device_id = device_info.get("deviceId")
+                        self._pillow_data = {
+                            "currentLevel": device_data.get("currentLevel"),
+                            "currentDeviceLevel": device_data.get("currentDeviceLevel"),
+                            "currentState": device_data.get("currentState", {}),
+                            "smart": device_data.get("smart", {}),
+                            "overrideLevels": device_data.get("overrideLevels", {}),
+                        }
+                        _LOGGER.debug(f"User {self.user_id} Pillow Data: {self._pillow_data}")
+                        break
+                else:
+                    # No pillow found
+                    self._pillow_data = None
+                    self._pillow_device_id = None
+        except Exception as e:
+            _LOGGER.warning(f"Error fetching pillow data for {self.user_id}: {e}")
+            self._pillow_data = None
+            self._pillow_device_id = None
 
 
     async def set_bed_side(self, side) -> None:
@@ -808,6 +898,43 @@ class EightUser:  # pylint: disable=too-many-public-methods
             _LOGGER.warning(f"ValueError converting current device level for user {self.user_id}: {e} - Response: {resp}")
             return None
         # RequestError will be raised by api_request if the call itself fails
+
+    # Pillow control methods
+    async def set_pillow_heating_level(self, level: int) -> None:
+        """Set pillow temperature level (-100 to 100)."""
+        if not self._pillow_data:
+            _LOGGER.warning(f"User {self.user_id} has no pillow device")
+            return
+
+        # Clamp level to valid range
+        level = max(-100, min(100, level))
+
+        url = APP_API_URL + f"v1/users/{self.user_id}/temperature/pillow?ignoreDeviceErrors=false"
+        data = {"currentLevel": level}
+        await self.device.api_request("PUT", url, data=data)
+        _LOGGER.debug(f"User {self.user_id}: Set pillow level to {level}")
+
+    async def turn_on_pillow(self) -> None:
+        """Turn on the pillow (smart mode)."""
+        if not self._pillow_data:
+            _LOGGER.warning(f"User {self.user_id} has no pillow device")
+            return
+
+        url = APP_API_URL + f"v1/users/{self.user_id}/temperature/pillow?ignoreDeviceErrors=false"
+        data = {"currentState": {"type": "smart"}}
+        await self.device.api_request("PUT", url, data=data)
+        _LOGGER.debug(f"User {self.user_id}: Turned on pillow")
+
+    async def turn_off_pillow(self) -> None:
+        """Turn off the pillow."""
+        if not self._pillow_data:
+            _LOGGER.warning(f"User {self.user_id} has no pillow device")
+            return
+
+        url = APP_API_URL + f"v1/users/{self.user_id}/temperature/pillow?ignoreDeviceErrors=false"
+        data = {"currentState": {"type": "off"}}
+        await self.device.api_request("PUT", url, data=data)
+        _LOGGER.debug(f"User {self.user_id}: Turned off pillow")
 
     async def prime_pod(self):
         url = APP_API_URL + f"v1/devices/{self.device.device_id}/priming/tasks"

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -95,6 +95,10 @@ EIGHT_USER_SENSORS = [
     "presence_end",
     "side",
     "routines",
+    # Pillow sensors
+    "pillow_temperature",
+    "pillow_target_temp",
+    "pillow_state",
 ]
 
 EIGHT_HEAT_SENSORS = ["bed_state"]
@@ -315,6 +319,18 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
             self._attr_device_class = SensorDeviceClass.TEMPERATURE
             self._attr_state_class = SensorStateClass.MEASUREMENT
             self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        elif self._sensor == "pillow_temperature":
+            self._attr_icon = "mdi:pillow"
+            self._attr_device_class = SensorDeviceClass.TEMPERATURE
+            self._attr_state_class = SensorStateClass.MEASUREMENT
+            self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        elif self._sensor == "pillow_target_temp":
+            self._attr_icon = "mdi:pillow"
+            self._attr_device_class = SensorDeviceClass.TEMPERATURE
+            self._attr_state_class = SensorStateClass.MEASUREMENT
+            self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        elif self._sensor == "pillow_state":
+            self._attr_icon = "mdi:pillow"
         elif self._sensor in (NAME_MAP):
             self._attr_native_unit_of_measurement = NAME_MAP[self._sensor].measurement
             self._attr_device_class = NAME_MAP[self._sensor].device_class
@@ -356,6 +372,12 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
             return self._user_obj.current_sleep_stage
         if self._sensor == "routines":
             return len(self._user_obj.alarms) if self._user_obj.alarms else 0
+        if self._sensor == "pillow_temperature":
+            return self._user_obj.pillow_current_temp if self._user_obj.has_pillow else None
+        if self._sensor == "pillow_target_temp":
+            return self._user_obj.pillow_target_temp if self._user_obj.has_pillow else None
+        if self._sensor == "pillow_state":
+            return self._user_obj.pillow_state if self._user_obj.has_pillow else None
 
         return None
 
@@ -390,6 +412,15 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
                     "thermal": alarm.get("thermal", {}),
                 })
             return {"alarms": alarms_data}
+        elif self._sensor == "pillow_temperature" and self._user_obj and self._user_obj.has_pillow:
+            smart = self._user_obj.pillow_smart_schedule or {}
+            return {
+                "current_level": self._user_obj.pillow_current_level,
+                "current_device_level": self._user_obj.pillow_current_device_level,
+                "bedtime_level": smart.get("bedTimeLevel"),
+                "initial_sleep_level": smart.get("initialSleepLevel"),
+                "final_sleep_level": smart.get("finalSleepLevel"),
+            }
 
         if attr is None:
             # Skip attributes if sensor type doesn't support

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -47,6 +47,7 @@ from .const import (
     NAME_MAP,
     SERVICE_REFRESH_DATA,
     SERVICE_SET_ONE_OFF_ALARM,
+    SERVICE_PILLOW_INCREMENT,
 )
 
 ATTR_ROOM_TEMP = "Room Temperature"
@@ -238,6 +239,11 @@ async def async_setup_entry(
         SERVICE_REFRESH_DATA,
         {},
         "async_refresh_data",
+    )
+    platform.async_register_entity_service(
+        SERVICE_PILLOW_INCREMENT,
+        SERVICE_HEAT_INCREMENT_SCHEMA,
+        "async_pillow_increment",
     )
 
 

--- a/custom_components/eight_sleep/switch.py
+++ b/custom_components/eight_sleep/switch.py
@@ -47,6 +47,8 @@ async def async_setup_entry(
     # Track entities per user keyed by alarm_id for dynamic add/remove
     tracked: dict[str, dict[str, EightSwitchEntity]] = {}
 
+    all_entities = []
+
     for user in eight.users.values():
         user_entities: dict[str, EightSwitchEntity] = {}
         for index, alarm in enumerate(user.alarms, start=1):
@@ -54,8 +56,13 @@ async def async_setup_entry(
             user_entities[alarm["id"]] = entity
         tracked[user.user_id] = user_entities
 
+        # Add pillow switch if user has a pillow
+        if user.has_pillow:
+            pillow_switch = EightPillowSwitchEntity(entry, coordinator, eight, user)
+            all_entities.append(pillow_switch)
+
     # Add all initial entities
-    all_entities = [e for user_map in tracked.values() for e in user_map.values()]
+    all_entities.extend([e for user_map in tracked.values() for e in user_map.values()])
     async_add_entities(all_entities)
 
     # Register a listener to dynamically add/remove entities on coordinator refresh
@@ -180,4 +187,47 @@ class EightSwitchEntity(EightSleepBaseEntity, SwitchEntity):
                     if alarm_time:
                         self._attr_name = f"Alarm {alarm_time[:5]}"
                     break
+        super()._handle_coordinator_update()
+
+
+class EightPillowSwitchEntity(EightSleepBaseEntity, SwitchEntity):
+    """Representation of an Eight Sleep pillow switch entity."""
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        coordinator: DataUpdateCoordinator,
+        eight: EightSleep,
+        user: EightUser,
+    ) -> None:
+        super().__init__(entry, coordinator, eight, user, "pillow_switch")
+        self._attr_name = "Pillow"
+        self._attr_icon = "mdi:pillow"
+        self._attr_extra_state_attributes = {}
+        self._update_attributes()
+
+    def _update_attributes(self) -> None:
+        if self._user_obj and self._user_obj.has_pillow:
+            state = self._user_obj.pillow_state
+            self._attr_is_on = state is not None and state != "off"
+            self._attr_extra_state_attributes["state"] = state
+            self._attr_extra_state_attributes["current_temp"] = self._user_obj.pillow_current_temp
+            self._attr_extra_state_attributes["target_temp"] = self._user_obj.pillow_target_temp
+            self._attr_extra_state_attributes["current_level"] = self._user_obj.pillow_current_level
+        else:
+            self._attr_is_on = False
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        if self._user_obj and self._user_obj.has_pillow:
+            await self._user_obj.turn_on_pillow()
+            await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        if self._user_obj and self._user_obj.has_pillow:
+            await self._user_obj.turn_off_pillow()
+            await self.coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._update_attributes()
         super()._handle_coordinator_update()

--- a/custom_components/eight_sleep/switch.py
+++ b/custom_components/eight_sleep/switch.py
@@ -218,12 +218,12 @@ class EightPillowSwitchEntity(EightSleepBaseEntity, SwitchEntity):
             self._attr_is_on = False
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        if self._user_obj and self._user_obj.has_pillow:
+        if self._user_obj:
             await self._user_obj.turn_on_pillow()
             await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        if self._user_obj and self._user_obj.has_pillow:
+        if self._user_obj:
             await self._user_obj.turn_off_pillow()
             await self.coordinator.async_request_refresh()
 


### PR DESCRIPTION
## Summary
Adds support for Eight Sleep pillow temperature monitoring and control for users with Pod 4 Ultra or compatible pillow devices.

## New Features

### Sensors
- `pillow_temperature` - Current pillow temperature (°C)
- `pillow_target_temp` - Target pillow temperature (°C)  
- `pillow_state` - Pillow state (on/off/smart)

### Switch
- `pillow` - Turn pillow on/off

### Number Control
- `pillow_level` - Set pillow temperature level (-100 to +100)

## Implementation Details

- Fetches pillow data from the `/v1/users/{user_id}/temperature/all` endpoint
- Identifies pillow device via `specialization: "pillow"` in the devices array
- Pillow control uses the dedicated `/v1/users/{user_id}/temperature/pillow` endpoint

## API Endpoints Used
- `GET app-api.8slp.net/v1/users/{user_id}/temperature/all` - Read pillow state
- `PUT app-api.8slp.net/v1/users/{user_id}/temperature/pillow?ignoreDeviceErrors=false` - Control pillow

## Testing
- ✅ Sensor readings verified working
- ✅ Turn on: `{"currentState": {"type": "smart"}}` - tested working
- ✅ Turn off: `{"currentState": {"type": "off"}}` - tested working  
- ✅ Set level: `{"currentLevel": <value>}` - tested working (requires pillow to be on)

## Notes
- Only users with pillow devices will see these entities
- Gracefully handles users without pillow (entities not created)