### PR TITLE
Fix phantom speaker coordinator on Pod 3: make speaker detection probe-authoritative

### DIFF
--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -298,16 +298,31 @@ class EightSleep:
         user = next(iter(self.users.values()))
         url = f"{APP_API_URL}v1/users/{user.user_id}/audio/player"
 
+        # Direct request, not api_request(): a 404 here means "no speaker",
+        # which api_request() would log at ERROR every call.
+        token_data = await self.token
+        headers = dict(DEFAULT_API_HEADERS)
+        headers["authorization"] = f"Bearer {token_data.bearer_token}"
+
+        assert self._api_session
         try:
-            response = await self.api_request("get", url)
-            # If we get a response with hardwareInfo, speaker is available
-            if response and response.get("hardwareInfo"):
-                _LOGGER.debug(f"Speaker detected via probe: {response.get('hardwareInfo', {}).get('sku')}")
-                return True
-            return False
-        except RequestError as e:
+            resp = await self._api_session.request(
+                "get", url, headers=headers, timeout=CLIENT_TIMEOUT
+            )
+            if resp.status == 404:
+                return False  # expected: no speaker
+            resp.raise_for_status()
+            data = await resp.json()
+        except (ClientError, asyncio.TimeoutError) as e:
             _LOGGER.debug(f"Speaker probe failed (expected if no speaker): {e}")
             return False
+
+        # If we get a response with hardwareInfo, speaker is available
+        hardware_info = data.get("hardwareInfo")
+        if hardware_info:
+            _LOGGER.debug(f"Speaker detected via probe: {hardware_info.get('sku')}")
+            return True
+        return False
 
     async def update_speaker_data(self) -> None:
         """Update data for the speaker."""
@@ -330,10 +345,8 @@ class EightSleep:
         await self.update_device_data()
         await self.assign_users()
 
-        # If speaker not detected via feature flag, try probe-based detection
-        # This handles Pod 4 hub + Pod 5 bed platform combinations
-        if not self._has_speaker:
-            self._has_speaker = await self._probe_speaker_availability()
+        # Probe authoritatively; the "audio" feature flag can't be trusted.
+        self._has_speaker = await self._probe_speaker_availability()
 
         # Fetch audio tracks if speaker available
         if self._has_speaker and self.speaker_user:
@@ -417,9 +430,6 @@ class EightSleep:
 
         if "elevation" in data["features"]:
             self._has_base = True
-
-        if "audio" in data["features"]:
-            self._has_speaker = True
 
         _LOGGER.debug(f"Device: {self.device_id}, Pod: {self._is_pod}, Base: {self._has_base}, Speaker: {self._has_speaker}")
 


### PR DESCRIPTION
## Problem

On a **Pod 3** (no paired speaker), the device's feature list still includes `"audio"`. `handle_device_json()` set `_has_speaker = True` from that flag, and `start()` only ran the authoritative `_probe_speaker_availability()` as a fallback (`if not self._has_speaker`). So the probe never ran, `has_speaker` stayed wrongly `True`, and `__init__` created a `speaker_coordinator` that polled `GET /v1/users/{id}/audio/player` every 60s — each returning a `404` ("No Associated Speaker" / `BaseNotPaired`) logged at ERROR, forever.

## Fix

- Drop the `"audio" in features` short-circuit in `handle_device_json()`.
- Run `_probe_speaker_availability()` **unconditionally** in `start()` and set `_has_speaker` from its result.
- Issue the probe request directly instead of via `api_request()` (which logs every non-2xx at ERROR). A `404` here is the normal "no speaker" answer, so a speaker-less startup is now silent.

The speaker case (Pod 4 hub + Pod 5 bed platform) is unchanged: a `200` carrying `hardwareInfo` still yields `has_speaker=True` and the speaker coordinator is still created.

## Soak

This has run on a personal fork against a live Pod 3 for >7 days (across HA restarts): zero `audio/player` 404s, no entity regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)