### PR TITLE
make HomeKit off handling independent of API timing

### DIFF
--- a/custom_components/eight_sleep/climate.py
+++ b/custom_components/eight_sleep/climate.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from time import monotonic
 from typing import Any
 
 from homeassistant.components.climate import (
+    ATTR_HVAC_MODE,
     ClimateEntity,
     ClimateEntityFeature,
     HVACAction,
@@ -40,10 +40,6 @@ TEMP_STEP = 1
 
 # Duration for heating/cooling in seconds (2 hours)
 DEFAULT_DURATION = 7200
-
-# Number of seconds after a power command during which the requested on/off state is
-# trusted over the (briefly stale) API state when deciding how to apply a setpoint.
-HVAC_MODE_LIFETIME = 60.0
 
 
 async def async_setup_entry(
@@ -97,7 +93,10 @@ class EightSleepThermostat(EightSleepBaseEntity, ClimateEntity, RestoreEntity):
         # temperature" pair cannot reorder at the Eight Sleep server.
         self._command_lock = asyncio.Lock()
         self._pending_hvac_mode: HVACMode | None = None
-        self._pending_hvac_mode_lifetime = 0.0
+        self._pending_hvac_mode_request_id = 0
+        self._pending_hvac_mode_request_complete = False
+        self._hvac_mode_task: asyncio.Task[Any] | None = None
+        self._hvac_mode_task_mode: HVACMode | None = None
         # Set temperature unit and ranges based on Home Assistant config
         self._attr_temperature_unit = hass.config.units.temperature_unit
         if self._attr_temperature_unit == UnitOfTemperature.CELSIUS:
@@ -152,11 +151,18 @@ class EightSleepThermostat(EightSleepBaseEntity, ClimateEntity, RestoreEntity):
         return None
 
     @property
-    def hvac_mode(self) -> HVACMode:
-        """Return current operation mode."""
+    def _api_hvac_mode(self) -> HVACMode:
+        """Return the operation mode reported by the API."""
         if self._user_obj and self._user_obj.bed_state_type != "off":
             return HVACMode.HEAT_COOL
         return HVACMode.OFF
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        """Return current operation mode."""
+        if (pending_hvac_mode := self._pending_hvac_mode) is not None:
+            return pending_hvac_mode
+        return self._api_hvac_mode
 
     @property
     def hvac_action(self) -> HVACAction | None:
@@ -164,7 +170,7 @@ class EightSleepThermostat(EightSleepBaseEntity, ClimateEntity, RestoreEntity):
         if not self._user_obj:
             return None
 
-        if self._user_obj.bed_state_type == "off":
+        if self.hvac_mode == HVACMode.OFF:
             return HVACAction.OFF
 
         if self._user_obj.now_heating:
@@ -211,13 +217,18 @@ class EightSleepThermostat(EightSleepBaseEntity, ClimateEntity, RestoreEntity):
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if (
+            self._pending_hvac_mode is not None
+            and self._pending_hvac_mode_request_complete
+            and self._pending_hvac_mode == self._api_hvac_mode
+        ):
+            self._record_pending_hvac_mode(None)
+
         # When ON, sync the API's target temperature to our local storage
         # so we persist Autopilot changes if the user turns the device off.
-        # Skip while a power-off is pending: `bed_state_type` can briefly still read ON
-        # after `turn_off_side()`, and a stale API value must not clobber a setpoint the
-        # user just requested (e.g. Apple HomeKit's temperature sent alongside "off").
-        if self.hvac_mode != HVACMode.OFF and not self._should_defer_temperature():
-             # Logic to read current target from API and update _attr_target_temperature
+        # Skip while a power command is pending: stale API values must not clobber a
+        # setpoint the user just requested.
+        if self._pending_hvac_mode is None and self._api_hvac_mode != HVACMode.OFF:
             heating_level_key = f"{self._user_obj.corrected_side_for_key}TargetHeatingLevel"
             raw_target_temp = self._eight.device_data.get(heating_level_key)
             if raw_target_temp is not None:
@@ -226,42 +237,39 @@ class EightSleepThermostat(EightSleepBaseEntity, ClimateEntity, RestoreEntity):
                     unit = convert_hass_temp_unit_to_pyeight_temp_unit(self.temperature_unit)
                     new_target = heating_level_to_temp(numeric_raw_target_temp, unit)
                     if self._attr_target_temperature != new_target:
-                         _LOGGER.debug(f"Syncing Autopilot/External change: {self._attr_target_temperature} -> {new_target}")
-                         self._attr_target_temperature = new_target
+                        _LOGGER.debug(f"Syncing Autopilot/External change: {self._attr_target_temperature} -> {new_target}")
+                        self._attr_target_temperature = new_target
                 except ValueError:
                     pass
         super()._handle_coordinator_update()
 
-    def _record_pending_hvac_mode(self, hvac_mode: HVACMode | None) -> None:
-        """Remember the last requested power state for a short grace period."""
+    def _record_pending_hvac_mode(self, hvac_mode: HVACMode | None) -> int:
+        """Remember the last requested power state until the API confirms it."""
         # `turn_on_side()`/`turn_off_side()` do not update `bed_state_type` locally, so the
-        # API state is briefly stale after a command. During that window we trust the
-        # requested state when deciding how to apply a setpoint (see
-        # `_should_defer_temperature`).
+        # requested state must remain authoritative until a coordinator update confirms it.
         self._pending_hvac_mode = hvac_mode
-        self._pending_hvac_mode_lifetime = (
-            monotonic() + HVAC_MODE_LIFETIME if hvac_mode is not None else 0.0
-        )
+        self._pending_hvac_mode_request_id += 1
+        self._pending_hvac_mode_request_complete = False
+        return self._pending_hvac_mode_request_id
 
     def _should_defer_temperature(self) -> bool:
         """Return True when a setpoint should be stored without powering the side on."""
         # Apple HomeKit turns a thermostat off by sending an "off" mode together with a target
-        # temperature. Because `set_heating_level()` always turns the side on, applying that
-        # temperature would immediately re-enable the side. When the side is off (or was just
-        # commanded off) we only remember the setpoint for the next power-on.
-        if monotonic() < self._pending_hvac_mode_lifetime:
+        # temperature. When the side is off (or was just commanded off), remember the setpoint
+        # for the next power-on instead of sending a time-based temperature override.
+        if self._pending_hvac_mode is not None:
             return self._pending_hvac_mode == HVACMode.OFF
         return self._user_obj is not None and self._user_obj.bed_state_type == "off"
 
     async def _async_apply_heating_level(self, temperature: float) -> None:
-        """Push a target temperature to the API, turning the side on."""
+        """Push a target temperature to the API without changing power state."""
         self._attr_target_temperature = temperature
 
         unit = convert_hass_temp_unit_to_pyeight_temp_unit(self.temperature_unit)
         level = temp_to_heating_level(temperature, unit)
 
         # Set temperature level with default duration
-        await self._user_obj.set_heating_level(level, DEFAULT_DURATION)
+        await self._user_obj.set_heating_level(level, DEFAULT_DURATION, power_on=False)
         await self._eight.update_device_data()
         # Refresh state
         await self.coordinator.async_refresh()
@@ -271,47 +279,91 @@ class EightSleepThermostat(EightSleepBaseEntity, ClimateEntity, RestoreEntity):
         if not self._user_obj:
             return
 
+        # HomeKit may send the same mode through both `set_hvac_mode` and
+        # `set_temperature`. Let both service calls wait for one API command.
+        if (
+            self._hvac_mode_task is not None
+            and self._hvac_mode_task_mode == hvac_mode
+        ):
+            await asyncio.shield(self._hvac_mode_task)
+            return
+        if self._pending_hvac_mode == hvac_mode:
+            return
+
         # Record the intent synchronously so a concurrent `async_set_temperature`
-        # (e.g. Apple HomeKit sends both) sees it before deciding whether to power on.
-        self._record_pending_hvac_mode(hvac_mode)
+        # sees it before deciding whether to send a temperature override.
+        request_id = self._record_pending_hvac_mode(hvac_mode)
+        task = self.hass.async_create_task(
+            self._async_set_hvac_mode(hvac_mode, request_id)
+        )
+        self._hvac_mode_task = task
+        self._hvac_mode_task_mode = hvac_mode
+        try:
+            await task
+        finally:
+            if self._hvac_mode_task is task:
+                self._hvac_mode_task = None
+                self._hvac_mode_task_mode = None
+
+    async def _async_set_hvac_mode(
+        self, hvac_mode: HVACMode, request_id: int
+    ) -> None:
+        """Send a serialized HVAC mode command."""
+        power_command_succeeded = False
         try:
             async with self._command_lock:
                 if hvac_mode == HVACMode.OFF:
                     await self._user_obj.turn_off_side()
                 else:
                     await self._user_obj.turn_on_side()
+                power_command_succeeded = True
+                if request_id == self._pending_hvac_mode_request_id:
+                    self._pending_hvac_mode_request_complete = True
+
+                if hvac_mode != HVACMode.OFF:
                     # Restore the target temperature if we have one
                     if self._attr_target_temperature is not None:
                         _LOGGER.debug("Turn On: Restoring target temperature to %s", self._attr_target_temperature)
                         await self._async_apply_heating_level(self._attr_target_temperature)
-        except Exception:
-            # On failure, forget the intent so setpoints fall back to real state.
-            self._record_pending_hvac_mode(None)
-            raise
 
-        # Refresh state
-        await self.coordinator.async_request_refresh()
+            # Refresh state
+            await self.coordinator.async_request_refresh()
+        finally:
+            if (
+                not power_command_succeeded
+                and request_id == self._pending_hvac_mode_request_id
+            ):
+                self._record_pending_hvac_mode(None)
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if not self._user_obj:
             return
 
-        if ATTR_TEMPERATURE not in kwargs:
-            return
-
-        temperature = kwargs[ATTR_TEMPERATURE]
-        if temperature < self.min_temp or temperature > self.max_temp:
+        requested_hvac_mode = kwargs.get(ATTR_HVAC_MODE)
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is not None and (
+            temperature < self.min_temp or temperature > self.max_temp
+        ):
             _LOGGER.warning(
                 "Temperature %s out of range (min: %s, max: %s)",
                 temperature,
                 self.min_temp,
                 self.max_temp,
             )
-            return
+            temperature = None
 
-        # Save target temperature
-        self._attr_target_temperature = temperature
+        if temperature is not None:
+            self._attr_target_temperature = temperature
+
+        if requested_hvac_mode is not None:
+            await self.async_set_hvac_mode(requested_hvac_mode)
+            self.async_write_ha_state()
+            if requested_hvac_mode == HVACMode.OFF:
+                return
+
+        if temperature is None:
+            return
 
         async with self._command_lock:
             if self._should_defer_temperature():

--- a/custom_components/eight_sleep/pyEight/tests/test_user.py
+++ b/custom_components/eight_sleep/pyEight/tests/test_user.py
@@ -58,6 +58,18 @@ class TestEightUser(unittest.IsolatedAsyncioTestCase):
         # Call 3: set_heating_level (timeBased)
         self.assertEqual(calls[2], call('PUT', expected_url, data={'timeBased': {'level': 50, 'durationSeconds': 7200}}))
 
+    async def test_set_heating_level_without_powering_on(self):
+        self.mock_eight_device.api_request = AsyncMock(return_value={})
+
+        await self.user.set_heating_level(level=50, duration=7200, power_on=False)
+
+        expected_url = f"{APP_API_URL}v1/users/{self.user_id}/temperature"
+        self.assertEqual(self.mock_eight_device.api_request.call_count, 2)
+
+        calls = self.mock_eight_device.api_request.call_args_list
+        self.assertEqual(calls[0], call('PUT', expected_url, data={'currentLevel': 50}))
+        self.assertEqual(calls[1], call('PUT', expected_url, data={'timeBased': {'level': 50, 'durationSeconds': 7200}}))
+
     @patch('custom_components.eight_sleep.pyEight.user.datetime') # Mock datetime within user.py
     async def test_set_away_mode_start(self, mock_datetime):
         self.mock_eight_device.api_request = AsyncMock(return_value={})

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -742,8 +742,8 @@ class EightUser:  # pylint: disable=too-many-public-methods
         data = await self.device.api_request("GET", url)
         return data["currentState"]["type"]
 
-    async def set_heating_level(self, level: int, duration: int = 0) -> None:
-        """Update heating data json."""
+    async def set_heating_level(self, level: int, duration: int = 0, *, power_on: bool = True) -> None:
+        """Update heating data, optionally powering on first."""
         url = APP_API_URL + f"v1/users/{self.user_id}/temperature"
         data_for_duration = {"timeBased": {"level": level, "durationSeconds": duration}}
         data_for_level = {"currentLevel": level}
@@ -752,7 +752,8 @@ class EightUser:  # pylint: disable=too-many-public-methods
         # Catch bad high inputs
         level = min(100, level)
 
-        await self.turn_on_side()  # Turn on side before setting temperature
+        if power_on:
+            await self.turn_on_side()
         await self.device.api_request(
             "PUT", url, data=data_for_level
         )  # Set heating level before duration


### PR DESCRIPTION
make HomeKit off handling independent of API timing

<https://github.com/lukas-clarke/eight_sleep/pull/132> serialized HomeKit's concurrent mode and temperature updates, but trusted the requested power state over stale API data for 60s

unfortunately, climate temperature updates still called `set_heating_level()`, which implicitly sent `currentState: smart` and powered the side on

`async_set_temperature()` also ignored the `hvac_mode` included by HomeKit in the same service call

as a result, a delayed temperature update, stale API state after the 60s window, or an `OFF` mode received through `set_temperature()` could still (re)enable the side

instead, honor the HVAC mode included in HomeKit's `set_temperature` service call, coalesce duplicate mode requests, and keep the requested mode authoritative until the API confirms the completed power command

this is done via request IDs so stale coordinator updates, failed commands, and cancellations cannot override a newer power-state request

with this change, climate temperature updates never send `currentState: smart`, temperatures requested while off are stored for later, and only an explicit HVAC mode change can power the side on