### PR TITLE
Fix KeyError: 'sku' when base hardwareInfo is missing or incomplete

### DIFF
--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -220,12 +220,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     if eight.base_user:
-        base_hardware_info = eight.base_user.base_data.get("hardwareInfo", {})
+        base_hardware_info = eight.base_user.base_data.get("hardwareInfo") or {}
         base_device_data = {
             ATTR_MANUFACTURER: "Eight Sleep",
-            ATTR_MODEL: base_hardware_info['sku'],
-            ATTR_HW_VERSION: base_hardware_info['hardwareVersion'],
-            ATTR_SW_VERSION: base_hardware_info['softwareVersion'],
+            ATTR_MODEL: base_hardware_info.get('sku'),
+            ATTR_HW_VERSION: base_hardware_info.get('hardwareVersion'),
+            ATTR_SW_VERSION: base_hardware_info.get('softwareVersion'),
         }
 
         dev_reg.async_get_or_create(


### PR DESCRIPTION
## Summary

Fixes #117.

`async_setup_entry` indexes `base_hardware_info['sku']` / `['hardwareVersion']` / `['softwareVersion']` directly right after a `.get("hardwareInfo", {})`. When the API returns `base_data` without `hardwareInfo` (or with a partial payload), setup raises `KeyError: 'sku'` and **the whole integration fails to load** — exactly the traceback in #117.

## Change

- Normalize a null `hardwareInfo` with `or {}` (covers `"hardwareInfo": null`).
- Use `.get()` for the three keys. The device registry accepts `None` for model/hw/sw, so a base with incomplete hardware info now registers with unknown fields instead of killing setup.

Minimal diff, no behavior change for well-formed payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)