### PR TITLE
Guard against empty timeseries lists in user.py getters (IndexError)

### DIFF
--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -106,13 +106,14 @@ class EightUser:  # pylint: disable=too-many-public-methods
         """Return the timeseries for the latest trend."""
         if not self.trends:
             return None
-        return self.trends[-1].get("sessions", [{}])[-1].get("timeseries", {})
+        sessions = self.trends[-1].get("sessions") or [{}]
+        return sessions[-1].get("timeseries", {})
 
     def _get_current_trend_property_value(self, key: str) -> int | float | None:
         """Get current property from trends."""
         if (
             not (timeseries_data := self._trend_timeseries())
-            or timeseries_data.get(key) is None
+            or not timeseries_data.get(key)
         ):
             return None
         return timeseries_data[key][-1][1]
@@ -219,7 +220,7 @@ class EightUser:  # pylint: disable=too-many-public-methods
         where no HR data was recorded in the current session.
         """
         timeseries = self._trend_timeseries()
-        if not timeseries or "heartRate" not in timeseries:
+        if not timeseries or not timeseries.get("heartRate"):
             return False
 
         heart_rate_entry = timeseries["heartRate"][-1]
@@ -466,7 +467,7 @@ class EightUser:  # pylint: disable=too-many-public-methods
     def current_room_temp(self) -> int | float | None:
         """Return current room temperature for in-progress session."""
         timeseries = self._trend_timeseries()
-        if timeseries and "tempRoomC" in timeseries:
+        if timeseries and timeseries.get("tempRoomC"):
             return timeseries["tempRoomC"][-1][1]
         return None
 
@@ -484,7 +485,7 @@ class EightUser:  # pylint: disable=too-many-public-methods
     def current_heart_rate(self) -> int | float | None:
         """Return current heart rate for in-progress session."""
         timeseries = self._trend_timeseries()
-        if timeseries and "heartRate" in timeseries:
+        if timeseries and timeseries.get("heartRate"):
             return timeseries["heartRate"][-1][1]
         return None
 


### PR DESCRIPTION
## Summary

Fixes #130.

The trends API can return a session whose timeseries keys exist but hold **empty lists** (e.g. a session that just started with no `heartRate` samples yet, or an empty `sessions` array on the latest trend). Several getters only checked key *presence* before indexing `[-1]`, so they raised `IndexError` — most visibly `bed_presence` crashing the coordinator refresh right after `async_set_temperature` (the traceback in #130):

```
File pyEight/user.py, in bed_presence
    heart_rate_entry = timeseries["heartRate"][-1]
IndexError: list index out of range
```

## Change

Same defensive pattern applied to every affected getter in `pyEight/user.py`:

| Getter | Bug |
|---|---|
| `_trend_timeseries` | `sessions == []` fell through to `[-1]` |
| `_get_current_trend_property_value` | key present but list empty |
| `bed_presence` | `heartRate` present but empty — the #130 crash |
| `current_room_temp` / `current_heart_rate` | same pattern |

Truthiness checks (`not .get(key)`) treat both `None` and `[]` as absent, so these getters now return their documented `None`/`False` instead of raising mid-refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)