### PR TITLE
Sync manifest.json version with releases + add CI drift check

### DIFF
--- a/.github/workflows/version_check.yaml
+++ b/.github/workflows/version_check.yaml
@@ -1,0 +1,21 @@
+name: Version check
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  manifest-matches-tag:
+    name: manifest.json version matches release tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compare manifest version with tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          MANIFEST=$(python3 -c "import json; print(json.load(open('custom_components/eight_sleep/manifest.json'))['version'])")
+          echo "release tag: $TAG · manifest: $MANIFEST"
+          if [ "$TAG" != "$MANIFEST" ]; then
+            echo "::error file=custom_components/eight_sleep/manifest.json::manifest version ($MANIFEST) does not match release tag ($TAG). Home Assistant reports the manifest version, so they must be bumped together."
+            exit 1
+          fi

--- a/.github/workflows/version_check.yaml
+++ b/.github/workflows/version_check.yaml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The release event already defaults to the tagged commit; being
+          # explicit keeps the intent clear if this workflow ever gains
+          # another trigger.
+          ref: ${{ github.event.release.tag_name }}
       - name: Compare manifest version with tag
         run: |
           TAG="${GITHUB_REF_NAME#v}"

--- a/custom_components/eight_sleep/manifest.json
+++ b/custom_components/eight_sleep/manifest.json
@@ -9,6 +9,6 @@
     "issue_tracker": "https://github.com/lukas-clarke/eight_sleep/issues",
     "loggers": ["pyEight"],
     "requirements": ["httpx", "aiohttp"],
-    "version": "1.0.22"
+    "version": "1.0.23"
 
 }


### PR DESCRIPTION
## Summary

Fixes #128.

`manifest.json` is stuck at `1.0.22` while releases moved to `1.0.23` (stable) and the `1.0.24` betas, so Home Assistant reports a stale integration version in Settings → Devices & Services and in diagnostics. It also muddies bug reports — e.g. #116 explicitly asks whether their `.22` is a manifest issue.

## Change

- Bump `version` to the current stable release (`1.0.23`) — one-line diff.
- Add `.github/workflows/version_check.yaml`: on every published release it compares the tag against the manifest version and fails loudly if they drift again, with a pointer to why it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)