### PR TITLE
Degrade gracefully when the alarms API requires a subscription (real root cause of #122)

### DIFF
--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -497,6 +497,7 @@ class EightSleep:
             if resp.status >= 400:
                 # Handle HTTP errors for non-401 or for 401 on retry
                 error_message = f"API request {method.upper()} {url} failed with status {resp.status}"
+                error_details = None
                 try:
                     error_details = await resp.json()
                     error_message += f" - Details: {error_details}"
@@ -507,7 +508,9 @@ class EightSleep:
                     except Exception as text_exc:
                         error_message += f" - Failed to get response text: {text_exc}"
                 _LOGGER.error(error_message)
-                raise RequestError(error_message)
+                raise RequestError(
+                    error_message, status=resp.status, error_details=error_details
+                )
 
             # Successful response
             if return_json:

--- a/custom_components/eight_sleep/pyEight/exceptions.py
+++ b/custom_components/eight_sleep/pyEight/exceptions.py
@@ -1,5 +1,6 @@
 """Exceptions for eight sleep."""
 
+from typing import Any
 
 from homeassistant.exceptions import HomeAssistantError
 
@@ -10,6 +11,16 @@ class BaseEightSleepError(Exception):
 
 class RequestError(HomeAssistantError):
     """Exception for eight sleep request failures."""
+
+    def __init__(
+        self,
+        message: str,
+        status: int | None = None,
+        error_details: Any = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.error_details = error_details
 
 
 class NotAuthenticatedError(BaseEightSleepError):

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -979,6 +979,15 @@ class EightUser:  # pylint: disable=too-many-public-methods
         trend_data = await self.device.api_request("get", url, params=params)
         self.trends = trend_data.get("days", [])
 
+    @staticmethod
+    def _is_subscription_required_error(err: RequestError) -> bool:
+        """Return True for the 403 "subscription required" alarms API error."""
+        if err.status != 403:
+            return False
+        if not isinstance(err.error_details, dict):
+            return False
+        return "subscription" in str(err.error_details.get("message", "")).lower()
+
     async def update_routines_data(self) -> None:
         """Update alarm data from the new /v2/alarms endpoint.
 
@@ -1008,6 +1017,8 @@ class EightUser:  # pylint: disable=too-many-public-methods
         try:
             resp = await self.device.api_request("GET", url)
         except RequestError as err:
+            if not self._is_subscription_required_error(err):
+                raise
             # Accounts without an active subscription get 403 "subscription
             # required" from the alarms API. Propagating the error here kills
             # the whole user coordinator on every refresh (#122), taking down

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -1005,7 +1005,19 @@ class EightUser:  # pylint: disable=too-many-public-methods
         }
         """
         url = APP_API_URL + f"v2/users/{self.user_id}/alarms"
-        resp = await self.device.api_request("GET", url)
+        try:
+            resp = await self.device.api_request("GET", url)
+        except RequestError as err:
+            # Accounts without an active subscription get 403 "subscription
+            # required" from the alarms API. Propagating the error here kills
+            # the whole user coordinator on every refresh (#122), taking down
+            # climate/sensors that don't need a subscription at all. Degrade
+            # gracefully instead: no alarm data, everything else keeps working.
+            _LOGGER.debug("Alarms unavailable for user %s: %s", self.user_id, err)
+            self.alarms = []
+            self.next_alarm = None
+            self.next_alarm_id = None
+            return
 
         self.alarms = resp.get("alarms", [])
 


### PR DESCRIPTION
## Summary

Fixes #122 — with a corrected root-cause analysis (my earlier comment there blamed the audio probe; that was wrong, and I've amended it).

The second log block in the issue body has the actual killer:

```
Unexpected error fetching eight_sleep_user data
  … update_user_data → user.update_user → update_routines_data
  → api_request GET /v2/users/{id}/alarms failed with status 403
  - Details: {'message': 'subscription required'}
```

`update_routines_data()` fetches the v2 alarms endpoint with **no error handling**. For accounts without an active subscription the 403 propagates through `update_user()` and fails the **entire user coordinator on every refresh** — taking down climate and sensors that don't need a subscription at all. This matches the reports in the thread: aurbman bisected it to the alarms changes (PR #120) and clin407 confirmed beta.1 (pre-alarms) works. Verified the fetch is still unguarded in current `main`.

The `audio/player` 404 lines in the same log are cosmetic (the old probe logging at ERROR level; the current raw-session probe in main no longer does this).

## Change

Wrap the alarms fetch in `try/except RequestError`: clear alarm state (`alarms=[]`, `next_alarm=None`, `next_alarm_id=None`) and continue, logging at debug (it fires every refresh for every non-subscriber). Alarm entities go unknown; everything else keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)