### PR TITLE
household.get_devices: return every pod (config flow could offer the pillow instead of the hub)

### DIFF
--- a/custom_components/eight_sleep/pyEight/household.py
+++ b/custom_components/eight_sleep/pyEight/household.py
@@ -24,16 +24,37 @@ class EightHousehold:
         user_data = await self.client.api_request("get", url)
         return user_data["user"]["userId"]
 
-    async def get_devices(self) -> dict[str, str]:
+    async def get_devices(self, specialization: str | None = "pod") -> dict[str, str]:
+        """Return {deviceId: label} for the household's devices.
+
+        A set can hold more than one device (e.g. a Pod 5 hub plus its
+        pillow, each with its own deviceId and specialization). The previous
+        implementation took ``sets[0][devices][0]`` only, which could
+        return the pillow instead of the pod and made any additional pod
+        unselectable in the config flow.
+
+        ``specialization`` filters the result ("pod" by default, matching the
+        config-flow use case). Devices without a specialization key (older
+        accounts) are treated as pods. Pass ``None`` to get everything.
+        """
         user_id = await self.get_user_id() if self.user_id is None else self.user_id
 
         url = APP_API_URL + f"v1/household/users/{user_id}/summary"
         data = await self.client.api_request("GET", url)
 
         self.devices = {}
-        for house_set in data["households"][0]["sets"]:
-            device = house_set["devices"][0]
-            self.devices[device["deviceId"]] = device["deviceName"]
+        for household in data.get("households") or []:
+            for house_set in household.get("sets") or []:
+                for device in house_set.get("devices") or []:
+                    device_spec = device.get("specialization") or "pod"
+                    if specialization is not None and device_spec != specialization:
+                        continue
+                    label = device.get("deviceName") or house_set.get("setName") or device["deviceId"]
+                    if specialization is None and device.get("specialization"):
+                        label = f"{label} ({device['specialization']})"
+                    if label in self.devices.values():
+                        label = f"{label} ({device['deviceId'][:6]})"
+                    self.devices[device["deviceId"]] = label
 
         return self.devices
         


### PR DESCRIPTION
## Summary

Groundwork for #116 and #138.

A household `set` can contain more than one device — e.g. a Pod 5 hub **plus its pillow**, each with its own `deviceId` and `specialization` (`"pod"` / `"pillow"`). `household.get_devices()` took `sets[*].devices[0]`, which has two consequences on such accounts:

1. The config-flow device picker can offer the **pillow's** deviceId labeled with the bed's name — the user unknowingly creates an entry pointed at the pillow.
2. The actual pod hub in that set (and anything in additional households) is **unselectable**, which is what makes multi-pod setups appear unsupported.

## Change

Iterate every household/set/device; filter by `specialization` (default `"pod"` — the config-flow use case; missing key on older accounts counts as pod; `None` returns everything, labeled with its specialization). Labels dedupe on collision.

## Validation

Ran the new logic against a **live 2-set household** (Pod 5 + pillow in one set, Pod 4 in another):

| | result |
|---|---|
| old code | `{pillow: "Recamara", pod4: "Kid room"}` — the master Pod 5 impossible to select |
| new (default) | `{pod5: "Recamara", pod4: "Kid room"}` ✅ |
| new (`None`) | all 3, labeled `(pod)` / `(pillow)` |

With this fix, multi-pod households work **today** by adding one config entry per pod from the picker (entries are already keyed by deviceId). I run that exact setup and can verify a branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)