### PR TITLE
Surface bedtime schedules in the routines sensor (routines stuck at 0)

### DIFF
--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -35,6 +35,8 @@ class EightUser:  # pylint: disable=too-many-public-methods
         self._base_data: dict[str, Any] = {}
         self.trends: list[dict[str, Any]] = []
         self.alarms: list[dict[str, Any]] = []
+        self.bedtime_schedules: list[dict[str, Any]] = []
+        self.schedule_type: str | None = None
         self.routines: list[dict[str, Any]] = []  # Kept for backward compat, always empty now
         self.smart_schedule: dict[str, Any] | None = None
         self.next_alarm = None
@@ -721,6 +723,20 @@ class EightUser:  # pylint: disable=too-many-public-methods
                 # Update smart schedule (Autopilot)
                 self.smart_schedule = resp.get("smart")
                 _LOGGER.debug(f"User {self.user_id} Smart Schedule: {self.smart_schedule}")
+
+                # Bedtime routines migrated here from the retired routines API:
+                # currentSchedule/nextSchedule carry time, days and startSettings
+                # (bed level, pillowBedtime, elevationPreset, audioSettings).
+                self.schedule_type = resp.get("scheduleType")
+                schedules: list[dict[str, Any]] = []
+                seen_ids: set[str] = set()
+                for key in ("currentSchedule", "nextSchedule"):
+                    sched = resp.get(key)
+                    sched_id = (sched or {}).get("id")
+                    if sched and sched_id and sched_id not in seen_ids:
+                        seen_ids.add(sched_id)
+                        schedules.append(sched)
+                self.bedtime_schedules = schedules
 
         except Exception as e:
             _LOGGER.warning(f"Error fetching temperature data for {self.user_id}: {e}")

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -355,7 +355,9 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
         if self._sensor == "sleep_stage":
             return self._user_obj.current_sleep_stage
         if self._sensor == "routines":
-            return len(self._user_obj.alarms) if self._user_obj.alarms else 0
+            alarms = len(self._user_obj.alarms) if self._user_obj.alarms else 0
+            schedules = len(getattr(self._user_obj, "bedtime_schedules", []) or [])
+            return alarms + schedules
 
         return None
 
@@ -389,7 +391,25 @@ class EightUserSensor(EightSleepBaseEntity, SensorEntity):
                     "vibration": alarm.get("vibration", {}),
                     "thermal": alarm.get("thermal", {}),
                 })
-            return {"alarms": alarms_data}
+            schedules_data = []
+            for sched in getattr(self._user_obj, "bedtime_schedules", []) or []:
+                start = sched.get("startSettings", {})
+                days = [day.capitalize() for day in sched.get("days", [])]
+                schedules_data.append({
+                    "id": sched.get("id"),
+                    "time": sched.get("time"),
+                    "enabled": sched.get("enabled", False),
+                    "days": days,
+                    "bedtime_level": start.get("bedtime"),
+                    "pillow_bedtime_level": start.get("pillowBedtime"),
+                    "elevation_preset": start.get("elevationPreset"),
+                    "audio": start.get("audioSettings", {}),
+                })
+            return {
+                "alarms": alarms_data,
+                "bedtime_schedules": schedules_data,
+                "schedule_type": getattr(self._user_obj, "schedule_type", None),
+            }
 
         if attr is None:
             # Skip attributes if sensor type doesn't support


### PR DESCRIPTION
## Summary

Fixes #111.

Eight Sleep migrated bedtime routines out of the retired routines API into `GET /v1/users/{id}/temperature` — its `currentSchedule`/`nextSchedule` carry the bedtime `time`, `days` and `startSettings` (bed level, `pillowBedtime`, `elevationPreset`, `audioSettings`). Payload documented in https://github.com/lukas-clarke/eight_sleep/issues/111#issuecomment-5161903865.

The integration **already fetches this endpoint** on every user refresh (`_update_temperature_data()`) but keeps only the `smart` block — so users whose routines are schedules rather than alarms (the OP's "2 bedtime settings") see the routines sensor stuck at `0` with no attributes.

## Change

- `user.py`: keep `scheduleType` and the deduped `currentSchedule`/`nextSchedule` list alongside `smart_schedule` (no extra API calls).
- `sensor.py`: routines state = alarms **+ bedtime schedules**; attributes gain `bedtime_schedules` (time, days, enabled, bed/pillow levels, elevation preset, audio) and `schedule_type` next to the existing `alarms` list.

## Validation

Ran the extraction against a live Pod 5 account payload (schedule-only user, no alarms):

| | before | after |
|---|---|---|
| state | `0` | `1` |
| attributes | `{alarms: []}` | `+ bedtime_schedules: [{time: "22:00:00", days: [Mon…Sun], enabled: true, bedtime_level: 68, pillow_bedtime_level: 44, elevation_preset: "sleep", audio: {…}}], schedule_type: "smart"` |

`current == next` schedules dedupe by id. Happy to iterate on naming/shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)