### PR TITLE
Harden setup against incomplete API payloads (audit follow-up to #135/#136)

### DIFF
--- a/custom_components/eight_sleep/__init__.py
+++ b/custom_components/eight_sleep/__init__.py
@@ -214,7 +214,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         dev_reg.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={(DOMAIN, _get_device_unique_id(eight, user))},
-            name=f"{user.user_profile['firstName']}'s Eight Sleep Side",
+            name=f"{(user.user_profile or {}).get('firstName') or user.side or 'Eight Sleep'}'s Eight Sleep Side",
             via_device=(DOMAIN, _get_device_unique_id(eight)),
             **device_data,
         )

--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -425,10 +425,11 @@ class EightSleep:
         """Manage the device json list."""
         self._device_json_list = [data, *self._device_json_list][:10]
 
-        if "cooling" in data["features"]:
+        features = data.get("features") or []
+        if "cooling" in features:
             self._is_pod = True
 
-        if "elevation" in data["features"]:
+        if "elevation" in features:
             self._has_base = True
 
         _LOGGER.debug(f"Device: {self.device_id}, Pod: {self._is_pod}, Base: {self._has_base}, Speaker: {self._has_speaker}")
@@ -438,7 +439,10 @@ class EightSleep:
         url = f"{CLIENT_API_URL}/users/me"
         dlist = await self.api_request("get", url)
 
-        self.device_id =  dlist["user"]["devices"][0]
+        devices = (dlist.get("user") or {}).get("devices") or []
+        if not devices:
+            raise RequestError("No devices associated with this Eight Sleep account")
+        self.device_id = devices[0]
 
     async def update_device_data(self) -> None:
         """Update device data json."""


### PR DESCRIPTION
## Summary

Follow-up to #135/#136: after fixing the reported crashes, I audited the rest of the setup path for the same failure class (direct indexing of API payloads). Three more, found by audit rather than crash report:

| Spot | Failure | Impact |
|---|---|---|
| `__init__.py` device registry | `user_profile['firstName']` → KeyError for profiles without a first name (e.g. **guest profiles**, which real households use for kids/guest rooms) | whole entry fails to load |
| `eight.py handle_device_json` | `data["features"]` → KeyError on payloads without a features list | runs on **every device refresh** |
| `eight.py fetch_device_id` | `["user"]["devices"][0]` → cryptic IndexError on accounts with no paired device | setup dies with no useful message |

## Change

- `firstName` falls back to the side name (`"left's Eight Sleep Side"`) instead of raising.
- `features` defaults to `[]`.
- Empty device list raises a descriptive `RequestError("No devices associated with this Eight Sleep account")` so the config flow shows something actionable (related: #102-style reports).

Minimal diffs, no behavior change for well-formed payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)