### PR TITLE
Fix away mode targeting wrong pod on multi-pod accounts

### DIFF
--- a/custom_components/eight_sleep/pyEight/tests/test_user.py
+++ b/custom_components/eight_sleep/pyEight/tests/test_user.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone # Import datetime for away_mo
 # Assuming similar import structure as test_auth.py
 from custom_components.eight_sleep.pyEight.eight import EightSleep
 from custom_components.eight_sleep.pyEight.user import EightUser
-from custom_components.eight_sleep.pyEight.constants import APP_API_URL # For URL construction
+from custom_components.eight_sleep.pyEight.constants import APP_API_URL, CLIENT_API_URL # For URL construction
 
 class TestEightUser(unittest.IsolatedAsyncioTestCase):
 
@@ -86,9 +86,62 @@ class TestEightUser(unittest.IsolatedAsyncioTestCase):
         expected_url = f"{APP_API_URL}v1/users/{self.user_id}/away-mode"
         expected_payload = {"awayPeriod": {"start": expected_api_timestamp}}
 
+        # set_away_mode must first re-sync this user's current-device/bed side so the
+        # away-mode call is scoped to the correct pod on multi-pod accounts (GH #116),
+        # then issue the away-mode call itself.
+        expected_bed_side_url = f"{CLIENT_API_URL}/users/{self.user_id}/current-device"
+        expected_bed_side_payload = {"id": str(self.mock_eight_device.device_id), "side": self.user_side}
+
+        self.assertEqual(self.mock_eight_device.api_request.call_count, 2)
+        calls = self.mock_eight_device.api_request.call_args_list
+        self.assertEqual(
+            calls[0], call('PUT', expected_bed_side_url, data=expected_bed_side_payload, return_json=False)
+        )
+        self.assertEqual(calls[1], call('PUT', expected_url, data=expected_payload))
+
+    @patch('custom_components.eight_sleep.pyEight.user.datetime')
+    async def test_set_away_mode_skips_bed_side_sync_when_side_unknown(self, mock_datetime):
+        """If we never learned this user's side, don't send an invalid current-device call."""
+        self.mock_eight_device.api_request = AsyncMock(return_value={})
+        self.user.side = None
+
+        fixed_utcnow = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.utcnow.return_value = fixed_utcnow
+        expected_api_timestamp = (fixed_utcnow - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+        await self.user.set_away_mode("start")
+
+        expected_url = f"{APP_API_URL}v1/users/{self.user_id}/away-mode"
+        expected_payload = {"awayPeriod": {"start": expected_api_timestamp}}
+
+        # Only the away-mode call should have been made; no current-device call.
         self.mock_eight_device.api_request.assert_called_once_with(
             'PUT', expected_url, data=expected_payload
         )
+
+    @patch('custom_components.eight_sleep.pyEight.user.datetime')
+    async def test_set_away_mode_still_proceeds_if_bed_side_sync_fails(self, mock_datetime):
+        """A failure syncing current-device shouldn't block the away-mode call itself."""
+        fixed_utcnow = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.utcnow.return_value = fixed_utcnow
+        expected_api_timestamp = (fixed_utcnow - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+        expected_bed_side_url = f"{CLIENT_API_URL}/users/{self.user_id}/current-device"
+        expected_away_url = f"{APP_API_URL}v1/users/{self.user_id}/away-mode"
+
+        async def api_request_side_effect(method, url, **kwargs):
+            if url == expected_bed_side_url:
+                raise Exception("boom")
+            return {}
+
+        self.mock_eight_device.api_request = AsyncMock(side_effect=api_request_side_effect)
+
+        await self.user.set_away_mode("start")
+
+        expected_payload = {"awayPeriod": {"start": expected_api_timestamp}}
+        calls = self.mock_eight_device.api_request.call_args_list
+        self.assertEqual(self.mock_eight_device.api_request.call_count, 2)
+        self.assertEqual(calls[1], call('PUT', expected_away_url, data=expected_payload))
 
     async def test_current_hrv_property_with_data(self):
         # Mock the user's trends data

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -942,6 +942,29 @@ class EightUser:  # pylint: disable=too-many-public-methods
 
     async def set_away_mode(self, action: str):
         """Sets the away mode. The action can either be 'start' or 'stop'"""
+        # The away-mode endpoint is user-scoped, but Eight Sleep's backend applies it to
+        # whichever pod is currently the account's "current device" rather than the pod
+        # this user actually belongs to. On accounts with multiple pods this can silently
+        # flip the wrong pod's away mode (see GH issue #116; the PR #109 device-id fix did
+        # not resolve this since it never re-asserts the current device before the call).
+        # Re-sync this user's bed side/current-device first so the away-mode call always
+        # lands on the pod that owns this entity, mirroring the set_bed_side workaround
+        # reported to fix this in practice.
+        if self.side:
+            try:
+                await self.set_bed_side(self.side)
+            except Exception as err:  # noqa: BLE001 - best effort, don't block away mode
+                _LOGGER.warning(
+                    f"User {self.user_id}: Could not sync current device (side '{self.side}') "
+                    f"before setting away mode; on multi-pod accounts this call may target the "
+                    f"wrong pod: {err}"
+                )
+        else:
+            _LOGGER.warning(
+                f"User {self.user_id}: No known bed side; skipping current-device sync before "
+                f"setting away mode. On multi-pod accounts this call may target the wrong pod."
+            )
+
         url = APP_API_URL + f"v1/users/{self.user_id}/away-mode"
         # Setting time to UTC of 24 hours ago to get API to trigger immediately
         now = str(


### PR DESCRIPTION
## Summary

Fixes #116. On accounts with more than one Eight Sleep pod, calling `eight_sleep.away_mode_start` / `eight_sleep.away_mode_stop` on one pod's entity could silently flip *another* pod's away mode instead.

Root cause: `EightUser.set_away_mode()` PUTs to the user-scoped `v1/users/{user_id}/away-mode` endpoint, which carries no device/pod identifier. Eight Sleep's backend applies it to whichever pod is currently the account's "current device," not necessarily the pod the target user/entity belongs to.

#109 (merged in v1.0.23) fixed a related bug where multi-pod accounts only ever got a single device_id fetched into HA, but it did not touch `set_away_mode()` itself and never re-asserts the current device before the away-mode call — so the original report reproduced on 1.0.23 exactly as described (confirmed by the reporter with explicit repro steps in the issue thread).

## Change

`EightUser.set_away_mode()` now re-syncs the current-device pointer for this user's side (via the existing `set_bed_side()` call, i.e. `PUT /users/{user_id}/current-device`) immediately before issuing the away-mode call. This mirrors the manual `set_bed_side` + `away_mode_start/stop` workaround from the issue thread, but does it automatically inside `pyEight` so every caller (HA services, and any other integration consumer) benefits, not just the `__init__.py` service handlers.

Edge cases handled conservatively:
- If the user's `side` was never learned (`None`), the sync call is skipped (it would be an invalid request anyway) and a warning is logged; away mode is still called as before.
- If the sync call itself raises, we log a warning and still proceed with the away-mode call rather than blocking the user's intent.

This is the "conservative" fix suggested in the issue thread (`set_bed_side`-equivalent before the away call), since a pod-scoped away-mode endpoint hasn't been confirmed to exist — the household summary payload shared by @proscar87 in the thread gives device/pairing data but no alternate away-mode route. If Eight Sleep's app is later found to use a dedicated pod-scoped endpoint, that would be a cleaner follow-up.

## Testing

- `python3 -m py_compile` on both changed files.
- Updated `custom_components/eight_sleep/pyEight/tests/test_user.py::test_set_away_mode_start` to assert the current-device sync call happens first, with the correct payload, followed by the away-mode call.
- Added two new tests: one confirming the sync call is skipped (not sent with an invalid payload) when `side` is unknown, and one confirming the away-mode call still proceeds even if the sync call fails.
- Since this repo has no `homeassistant` package installed and no formal test runner wired up, I additionally wrote a standalone script that stubs the minimal `homeassistant.exceptions.HomeAssistantError` surface `pyEight/exceptions.py` needs, imports `pyEight.user.EightUser` directly, and exercises `set_away_mode()` against a mocked device across the three scenarios above (correct pod targeted, unknown side, sync failure) — all assertions passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)