### PR TITLE
Sync manifest version with the released version (prevents HACS offering 1.0.23 as an "update" to 1.0.24 betas)

### DIFF
--- a/custom_components/eight_sleep/manifest.json
+++ b/custom_components/eight_sleep/manifest.json
@@ -9,6 +9,6 @@
     "issue_tracker": "https://github.com/lukas-clarke/eight_sleep/issues",
     "loggers": ["pyEight"],
     "requirements": ["httpx", "aiohttp"],
-    "version": "1.0.22"
+    "version": "1.0.24.beta.4"
 
 }


### PR DESCRIPTION
`manifest.json` has declared `"version": "1.0.22"` throughout the 1.0.24 beta line, so every installed beta self-reports as 1.0.22.

HACS compares that installed version against the latest full release — currently **1.0.23** — and offers it as an available *update*. For anyone running 1.0.24.beta.x, accepting it is actually a **downgrade** to the pre-beta code, silently reintroducing the bugs the betas fixed (e.g. the `get_alarm_enabled` failure that takes down the switch platform when `settings.routines` comes back empty). The UI gives no hint anything went backwards, which likely feeds some recurring "it broke after I updated" reports.

This PR bumps the manifest to `1.0.24.beta.4` to match the current release.

Longer-term, a small release-workflow step that stamps `manifest.json`'s version from the git tag at release time would make this drift impossible — happy to send that as a follow-up PR if you're open to it.