### PR TITLE
fix: stop dropping base commands and crashing the speaker entity

### DIFF
--- a/custom_components/eight_sleep/media_player.py
+++ b/custom_components/eight_sleep/media_player.py
@@ -75,10 +75,22 @@ class EightSleepMediaPlayer(EightSleepBaseEntity, MediaPlayerEntity):
         self._attr_name = "Speaker"
 
     @property
-    def state(self) -> MediaPlayerState:
+    def available(self) -> bool:
+        """Return whether the speaker has reported any state yet."""
+        return bool(
+            super().available
+            and self._eight.speaker_user
+            and self._eight.speaker_user.player_state
+        )
+
+    @property
+    def state(self) -> MediaPlayerState | None:
         """Return the state of the player."""
+        # MediaPlayerState has no UNAVAILABLE member -- returning one raised
+        # AttributeError on every state write, which HA logs as "Unexpected
+        # error updating listener". Unavailability belongs on `available`.
         if not self._eight.speaker_user or not self._eight.speaker_user.player_state:
-            return MediaPlayerState.UNAVAILABLE
+            return None
 
         state = self._eight.speaker_user.player_state.get("state", "").lower()
         if state == "playing":

--- a/custom_components/eight_sleep/pyEight/tests/test_media_player.py
+++ b/custom_components/eight_sleep/pyEight/tests/test_media_player.py
@@ -1,0 +1,68 @@
+"""Tests for the Eight Sleep media player entity."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.media_player import MediaPlayerState
+
+from custom_components.eight_sleep.media_player import EightSleepMediaPlayer
+from custom_components.eight_sleep.pyEight.eight import EightSleep
+
+
+def _build_player(player_state):
+    """Build the entity with a speaker user whose player_state is given."""
+    eight = MagicMock(spec=EightSleep)
+    eight.device_id = "fake_device_id"
+    if player_state is None:
+        eight.speaker_user = None
+    else:
+        speaker_user = MagicMock()
+        speaker_user.player_state = player_state
+        speaker_user.user_id = "user_1"
+        eight.speaker_user = speaker_user
+
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    entry = MagicMock()
+    entry.entry_id = "entry_1"
+
+    with patch.object(EightSleepMediaPlayer, "__init__", lambda self, *a, **k: None):
+        player = EightSleepMediaPlayer(entry, coordinator, eight)
+    player._eight = eight
+    player.coordinator = coordinator
+    return player
+
+
+class TestEightSleepMediaPlayerState(unittest.TestCase):
+    """The speaker must not raise when the hub has no speaker paired (#144)."""
+
+    def test_media_player_state_has_no_unavailable_member(self):
+        """Guards the premise: MediaPlayerState.UNAVAILABLE does not exist."""
+        self.assertFalse(hasattr(MediaPlayerState, "UNAVAILABLE"))
+
+    def test_state_without_speaker_user_does_not_raise(self):
+        """GET /audio/player answers 404 BaseNotPaired on hubs with no speaker."""
+        player = _build_player(None)
+
+        self.assertIsNone(player.state)
+
+    def test_state_without_player_state_does_not_raise(self):
+        """A speaker user that has never reported state must not raise either."""
+        player = _build_player({})
+
+        self.assertIsNone(player.state)
+
+    def test_entity_reports_unavailable_instead(self):
+        """Unavailability belongs on `available`, not on the state enum."""
+        self.assertFalse(_build_player(None).available)
+        self.assertFalse(_build_player({}).available)
+
+    def test_known_states_still_map(self):
+        """The real states must keep working."""
+        self.assertEqual(_build_player({"state": "playing"}).state, MediaPlayerState.PLAYING)
+        self.assertEqual(_build_player({"state": "paused"}).state, MediaPlayerState.PAUSED)
+        self.assertEqual(_build_player({"state": "stopped"}).state, MediaPlayerState.IDLE)
+        self.assertTrue(_build_player({"state": "playing"}).available)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/custom_components/eight_sleep/pyEight/tests/test_user.py
+++ b/custom_components/eight_sleep/pyEight/tests/test_user.py
@@ -144,5 +144,65 @@ class TestEightUser(unittest.IsolatedAsyncioTestCase):
             mock_logger.warning.assert_called_once()
 
 
+class TestEightUserBase(unittest.IsolatedAsyncioTestCase):
+    """Tests for bed base control when base data is missing or partial (#144)."""
+
+    def setUp(self):
+        self.mock_eight_device = AsyncMock(spec=EightSleep)
+        self.mock_eight_device.timezone = "America/New_York"
+        self.mock_eight_device.device_data = {}
+        self.mock_eight_device.device_id = "fake_device_id"
+        self.mock_eight_device.has_base = True
+        self.user = EightUser(self.mock_eight_device, "test_user_123", "left")
+        self.user._base_data = {}
+
+    async def test_set_base_angle_without_base_data_still_sends_request(self):
+        """An empty _base_data must not stop the command from reaching the API.
+
+        `update_base_data` swallows a failed GET /base (the API answers 404
+        BaseOffline when the frame is unplugged), leaving _base_data empty. The
+        optimistic local write then raised KeyError *before* the POST, so the
+        user's request was silently dropped.
+        """
+        self.mock_eight_device.api_request = AsyncMock()
+
+        await self.user.set_base_angle(leg_angle=10, torso_angle=20)
+
+        self.mock_eight_device.api_request.assert_awaited_once()
+        args, kwargs = self.mock_eight_device.api_request.await_args
+        self.assertEqual(args[0], "POST")
+        self.assertEqual(kwargs["data"]["legAngle"], 10)
+        self.assertEqual(kwargs["data"]["torsoAngle"], 20)
+
+    async def test_set_base_angle_with_partial_base_data(self):
+        """Only one of the two angle keys present must not raise either."""
+        self.user._base_data = {"left": {"leg": {"currentAngle": 0}}}
+        self.mock_eight_device.api_request = AsyncMock()
+
+        await self.user.set_base_angle(leg_angle=5, torso_angle=15)
+
+        self.mock_eight_device.api_request.assert_awaited_once()
+
+    async def test_set_base_angle_updates_local_state_when_present(self):
+        """The optimistic local update must still happen when the keys exist."""
+        self.user._base_data = {
+            "left": {"leg": {"currentAngle": 0}, "torso": {"currentAngle": 0}}
+        }
+        self.mock_eight_device.api_request = AsyncMock()
+
+        await self.user.set_base_angle(leg_angle=7, torso_angle=12)
+
+        self.assertEqual(self.user.leg_angle, 7)
+        self.assertEqual(self.user.torso_angle, 12)
+
+    async def test_set_base_preset_without_base_data_still_sends_request(self):
+        """set_base_preset must survive empty base data the same way."""
+        self.mock_eight_device.api_request = AsyncMock()
+
+        await self.user.set_base_preset("sleep")
+
+        self.mock_eight_device.api_request.assert_awaited_once()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/custom_components/eight_sleep/pyEight/user.py
+++ b/custom_components/eight_sleep/pyEight/user.py
@@ -1096,12 +1096,28 @@ class EightUser:  # pylint: disable=too-many-public-methods
                     self.user_id,
                 )
 
+    def _set_base_angle_locally(self, leg_angle: int, torso_angle: int) -> None:
+        """Apply the optimistic angle update to cached base data, if any.
+
+        base_data_for_side returns a throwaway dict when the side is absent, so
+        writing into it would be a no-op that merely looks like an update. Only
+        mutate the real cached side.
+        """
+        side_data = self.base_data.get(self.corrected_side_for_key)
+        if side_data is None:
+            return
+        side_data.setdefault("leg", {})["currentAngle"] = leg_angle
+        side_data.setdefault("torso", {})["currentAngle"] = torso_angle
+
     async def set_base_angle(self, leg_angle: int, torso_angle: int) -> None:
         """Set the angles of the bed base."""
         if self.device.has_base:
-            # Update the angles locally
-            self.base_data_for_side["leg"]["currentAngle"] = leg_angle
-            self.base_data_for_side["torso"]["currentAngle"] = torso_angle
+            # Update the angles locally, when there is local state to update.
+            # update_base_data() swallows a failed GET /base -- the API answers
+            # 404 BaseOffline while the frame is unplugged -- so _base_data can
+            # be empty or partial. Indexing it blindly raised KeyError *before*
+            # the request below, silently dropping the user's command.
+            self._set_base_angle_locally(leg_angle, torso_angle)
 
             url = f"{APP_API_URL}v1/users/{self.user_id}/base/angle?ignoreDeviceErrors=false"
             payload = {


### PR DESCRIPTION
Two independent failures, both caught on a live account (Pod 5 + TriMix base and a Pod 4 + base in a second household) and both reproduced in tests before fixing.

## 1. `set_base_angle` raised `KeyError` before the request went out

```
Error doing job: Task exception was never retrieved
  File "custom_components/eight_sleep/pyEight/user.py", line 1046, in set_base_angle
    self.base_data_for_side["leg"]["currentAngle"] = leg_angle
KeyError: 'leg'
```

`update_base_data()` catches `RequestError` and only warns, so `_base_data` stays empty whenever the API refuses the call. On the second bed it does exactly that:

```
GET /v1/users/<id>/base → 404 {"message": "Frame is not connected", "errorType": "BaseOffline"}
```

The optimistic local write then indexed that empty dict and threw — **before** the POST. So moving the base did nothing at all, and because the task's exception is never retrieved, the user gets no error either. It just silently doesn't work.

Fixed by guarding the local update. Note it skips rather than writes when the side is absent: `base_data_for_side` returns a fresh throwaway dict in that case, so writing into it would be a no-op that merely looks like an update.

While there: the warning text says *"This is normal if the user is not paired to a base"*, but the API said `BaseOffline`, not unpaired. That makes a real hardware fault read as expected behaviour. Left alone here to keep the diff focused — happy to follow up if you'd like it to reflect the actual `errorType`.

## 2. `MediaPlayerState.UNAVAILABLE` does not exist

```
AttributeError: type object 'MediaPlayerState' has no attribute 'UNAVAILABLE'
  File "custom_components/eight_sleep/media_player.py", line 81, in state
    return MediaPlayerState.UNAVAILABLE
```

The enum has `OFF`, `ON`, `IDLE`, `PLAYING`, `PAUSED`, `STANDBY`, `BUFFERING` — and no `UNAVAILABLE`. Since it's raised from the `state` property, it fires on **every** state write, logged as `Unexpected error updating listener ... eight_sleep_speaker`. It appeared about twenty times in a single day's log on a hub whose `GET /audio/player` answers:

```
404 {"message": "No Associated Speaker", "errorType": "BaseNotPaired"}
```

`state` now returns `None` and unavailability moved to an `available` property, which is where HA expects it. A test pins the premise directly (`hasattr(MediaPlayerState, "UNAVAILABLE")` is `False`) so this can't silently regress if the enum ever changes.

## Validation

Written against the unfixed code first:

- base tests: **2 fail** (`KeyError: 'leg'`), 2 pass — those two are regression guards for the paths that already worked
- speaker tests: **3 fail**, 2 pass
- with the fixes: all 9 pass

Suite before and after, on the same environment:

| | result |
|---|---|
| `main`, untouched | 5 failed, 30 passed |
| this branch | 5 failed, 39 passed |

**The 5 failures are pre-existing on `main`** (`test_auth::test_start_successful`, two in `test_eight`, two in `test_speaker`) and are identical before and after — nothing here touches them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
