### PR TITLE
fix: stop moving the bed on every Home Assistant restart

### DIFF
--- a/custom_components/eight_sleep/number.py
+++ b/custom_components/eight_sleep/number.py
@@ -84,7 +84,8 @@ async def async_setup_entry(
                 user,
                 FEET_DESCRIPTION,
                 lambda: user.leg_angle,
-                set_leg_angle),
+                set_leg_angle,
+                restore_previous=False),
             EightNumberEntity(
                 entry,
                 coordinator,
@@ -92,7 +93,8 @@ async def async_setup_entry(
                 user,
                 HEAD_DESCRIPTION,
                 lambda: user.torso_angle,
-                set_torso_angle)])
+                set_torso_angle,
+                restore_previous=False)])
 
     async_add_entities(entities)
 
@@ -109,15 +111,25 @@ class EightNumberEntity(EightSleepBaseEntity, NumberEntity, RestoreEntity):
         value_getter: Callable[[], float | None],
         set_value_callback: Callable[[float], None],
         base_entity: bool = True,
+        restore_previous: bool = True,
     ):
         super().__init__(entry, coordinator, eight, user, entity_description.key, base_entity=base_entity)
         self.entity_description = entity_description
         self._value_getter = value_getter
         self._set_value_callback = set_value_callback
+        self._restore_previous = restore_previous
 
     async def async_added_to_hass(self) -> None:
-        """Restore previous value on startup."""
+        """Restore the previous value, for values Home Assistant alone holds.
+
+        Entities backed by state the device itself reports must not restore:
+        the setter is a real command, so a stale value is pushed back to the
+        hardware on every restart, overriding whatever changed while Home
+        Assistant was down.
+        """
         await super().async_added_to_hass()
+        if not self._restore_previous:
+            return
         last_state = await self.async_get_last_state()
         if last_state and last_state.state not in (None, "unknown", "unavailable"):
             try:

--- a/custom_components/eight_sleep/pyEight/tests/test_number_restore.py
+++ b/custom_components/eight_sleep/pyEight/tests/test_number_restore.py
@@ -1,0 +1,80 @@
+"""Values the device owns must not be pushed back on startup."""
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.eight_sleep.number import (
+    FEET_DESCRIPTION,
+    HEAD_DESCRIPTION,
+    SNOOZE_MINUTES_DESCRIPTION,
+    EightNumberEntity,
+)
+
+
+def _entity(restore_previous):
+    ent = EightNumberEntity.__new__(EightNumberEntity)
+    ent._restore_previous = restore_previous
+    ent._set_value_callback = MagicMock()
+    return ent
+
+
+async def _added(ent, last_state):
+    with patch.object(
+        EightNumberEntity, "async_get_last_state", AsyncMock(return_value=last_state)
+    ) as leer, patch(
+        "custom_components.eight_sleep.EightSleepBaseEntity.async_added_to_hass",
+        AsyncMock(),
+    ):
+        await EightNumberEntity.async_added_to_hass(ent)
+    return leer
+
+
+class TestNumberRestore(unittest.IsolatedAsyncioTestCase):
+    """Restoring a base angle re-sends a real command that moves the bed."""
+
+    async def test_no_restore_does_not_call_the_setter(self):
+        ent = _entity(restore_previous=False)
+        estado = MagicMock()
+        estado.state = "12"
+
+        await _added(ent, estado)
+
+        ent._set_value_callback.assert_not_called()
+
+    async def test_no_restore_does_not_even_read_the_last_state(self):
+        ent = _entity(restore_previous=False)
+
+        leer = await _added(ent, None)
+
+        leer.assert_not_awaited()
+
+    async def test_restore_still_works_where_it_is_wanted(self):
+        """Snooze minutes has no server-side counterpart; it must keep restoring."""
+        ent = _entity(restore_previous=True)
+        estado = MagicMock()
+        estado.state = "12"
+
+        await _added(ent, estado)
+
+        ent._set_value_callback.assert_called_once_with(12.0)
+
+    async def test_restore_ignores_unusable_states(self):
+        for valor in ("unknown", "unavailable", "not-a-number"):
+            with self.subTest(valor=valor):
+                ent = _entity(restore_previous=True)
+                estado = MagicMock()
+                estado.state = valor
+
+                await _added(ent, estado)
+
+                ent._set_value_callback.assert_not_called()
+
+    def test_default_keeps_the_previous_behaviour(self):
+        """Anything not opting out must still restore, so nothing else changes."""
+        import inspect
+
+        firma = inspect.signature(EightNumberEntity.__init__)
+        self.assertIs(firma.parameters["restore_previous"].default, True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`EightNumberEntity` restores its last state in `async_added_to_hass` and calls the setter. For snooze minutes that's right — Home Assistant alone holds that value. For the **base angles** the setter is a real command:

```
POST app-api /v1/users/{userId}/base/angle   {"legAngle": …, "torsoAngle": …}
```

I verified that request physically moves the base on a live unit: torso went `0 → 12 → 0`, confirmed by reading `/base` back between steps, and the original position was restored.

So on every Home Assistant restart, the integration drives the bed to whichever angle it happened to remember — **overriding anything changed in the Eight Sleep app while HA was down.** Usually invisible, because the restored value equals the current one; it only bites when they diverge, which is exactly when someone adjusted the bed by hand.

## The change

Added `restore_previous`, defaulting to `True` so every existing entity keeps its behaviour, and set it `False` for the feet and head angles. Snooze minutes keeps restoring, since it has no server-side counterpart to conflict with.

The general rule the flag encodes: **an entity whose value the device itself reports must not restore**, because its setter is a command rather than a local assignment.

## Validation

Five tests: setter not called when restore is off, the last state not even read, restore still working where it's wanted, unusable states (`unknown` / `unavailable` / non-numeric) ignored, and the default still `True` so nothing silently changes. **Three fail against the previous version.**

I did not test this end to end by restarting HA with a divergent angle, because that would move a bed someone might be in. The two halves are each verified separately: the restore path calls the setter (plain code), and the setter moves the base (verified against hardware).

## Overlap with #147

That PR introduces the same flag for the hub light, for the same reason. **This one should land first** — it's a bug fix with a physical consequence, where #147 is a new feature. If you take this one, #147 rebases down to just its own entity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
