### PR TITLE
fix: register the set_routine_alarm and set_routine_bedtime services

### DIFF
--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -231,6 +231,27 @@ async def async_setup_entry(
         "async_set_bed_side",
     )
     platform.async_register_entity_service(
+        "set_routine_alarm",
+        {
+            vol.Required("routine_id"): vol.All(vol.Coerce(str)),
+            vol.Required("alarm_id"): vol.All(vol.Coerce(str)),
+            # pyEight sends this straight through as the "time" field of a
+            # JSON PUT body (set_alarm_time()); cv.time would hand it a
+            # datetime.time object that aiohttp's default JSON encoder can't
+            # serialize, so keep it as the string the API expects.
+            vol.Required("alarm_time"): vol.All(vol.Coerce(str)),
+        },
+        "async_set_routine_alarm",
+    )
+    platform.async_register_entity_service(
+        "set_routine_bedtime",
+        {
+            vol.Required("routine_id"): vol.All(vol.Coerce(str)),
+            vol.Required("bedtime"): vol.All(vol.Coerce(str)),
+        },
+        "async_set_routine_bedtime",
+    )
+    platform.async_register_entity_service(
         SERVICE_REFRESH_DATA,
         {},
         "async_refresh_data",

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -244,14 +244,6 @@ async def async_setup_entry(
         "async_set_routine_alarm",
     )
     platform.async_register_entity_service(
-        "set_routine_bedtime",
-        {
-            vol.Required("routine_id"): vol.All(vol.Coerce(str)),
-            vol.Required("bedtime"): vol.All(vol.Coerce(str)),
-        },
-        "async_set_routine_bedtime",
-    )
-    platform.async_register_entity_service(
         SERVICE_REFRESH_DATA,
         {},
         "async_refresh_data",

--- a/custom_components/eight_sleep/services.yaml
+++ b/custom_components/eight_sleep/services.yaml
@@ -131,20 +131,6 @@ set_routine_alarm:
       required: true
       selector:
         time:
-set_routine_bedtime:
-  target:
-    entity:
-      integration: eight_sleep
-      domain: sensor
-  fields:
-    routine_id:
-      required: true
-      selector:
-        text:
-    bedtime:
-      required: true
-      selector:
-        time:
 
 set_one_off_alarm:
   target:

--- a/tests/test_sensor_services.py
+++ b/tests/test_sensor_services.py
@@ -3,12 +3,18 @@ registered by sensor.async_setup_entry() (#101).
 
 services.yaml is what Home Assistant's UI and docs read to offer a
 service as callable; it does not by itself wire the service to a
-handler. `set_routine_alarm` and `set_routine_bedtime` were declared
-there, and their `async_set_routine_alarm`/`async_set_routine_bedtime`
-handler methods exist on the entity, but nothing ever called
-`platform.async_register_entity_service()` for them -- so calling
-either from an automation raises "Unable to find service", which is
-exactly what the Spook integration flags as an unknown action.
+handler. `set_routine_alarm` was declared there, and its
+`async_set_routine_alarm` handler method exists on the entity, but
+nothing ever called `platform.async_register_entity_service()` for it --
+so calling it from an automation raised "Unable to find service", which
+is exactly what the Spook integration flags as an unknown action.
+
+`set_routine_bedtime` was declared alongside it but is deliberately left
+unregistered (and removed from services.yaml): its handler,
+`EightUser.set_routine_bedtime()`, is a no-op that only logs a warning --
+Eight Sleep's API no longer supports bedtime routines. Registering it
+would silence the unknown-service error while making automations that
+call it appear to succeed without doing anything.
 """
 
 from pathlib import Path
@@ -59,3 +65,36 @@ async def test_every_declared_service_is_registered():
     assert not missing, (
         f"Declared in services.yaml but never registered: {sorted(missing)}"
     )
+
+
+def test_set_routine_bedtime_is_not_declared():
+    """set_routine_bedtime must stay out of services.yaml until its handler
+    does something other than log a warning -- see #152 review discussion."""
+    assert "set_routine_bedtime" not in _declared_service_names()
+
+
+@pytest.mark.asyncio
+async def test_set_routine_bedtime_is_not_registered():
+    """set_routine_bedtime must not be wired to a service even if someone
+    re-adds it to services.yaml without also fixing the handler."""
+    entry = MagicMock(entry_id="test_entry")
+    config_entry_data = MagicMock(users={})
+    config_entry_data.api.users = {}
+    config_entry_data.api.device_id = "test-device-id"
+
+    hass = MagicMock()
+    hass.data = {DOMAIN: {entry.entry_id: config_entry_data}}
+
+    platform = MagicMock()
+    registered_service_names: set[str] = set()
+    platform.async_register_entity_service.side_effect = (
+        lambda name, *_args, **_kwargs: registered_service_names.add(name)
+    )
+
+    with patch(
+        "custom_components.eight_sleep.sensor.async_get_current_platform",
+        return_value=platform,
+    ):
+        await async_setup_entry(hass, entry, MagicMock())
+
+    assert "set_routine_bedtime" not in registered_service_names

--- a/tests/test_sensor_services.py
+++ b/tests/test_sensor_services.py
@@ -1,0 +1,61 @@
+"""Verify every entity service declared in services.yaml is actually
+registered by sensor.async_setup_entry() (#101).
+
+services.yaml is what Home Assistant's UI and docs read to offer a
+service as callable; it does not by itself wire the service to a
+handler. `set_routine_alarm` and `set_routine_bedtime` were declared
+there, and their `async_set_routine_alarm`/`async_set_routine_bedtime`
+handler methods exist on the entity, but nothing ever called
+`platform.async_register_entity_service()` for them -- so calling
+either from an automation raises "Unable to find service", which is
+exactly what the Spook integration flags as an unknown action.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from custom_components.eight_sleep.const import DOMAIN
+from custom_components.eight_sleep.sensor import async_setup_entry
+
+SERVICES_YAML = (
+    Path(__file__).parent.parent / "custom_components" / "eight_sleep" / "services.yaml"
+)
+
+
+def _declared_service_names() -> set[str]:
+    with SERVICES_YAML.open() as f:
+        return set(yaml.safe_load(f).keys())
+
+
+@pytest.mark.asyncio
+async def test_every_declared_service_is_registered():
+    """Every service name in services.yaml must reach
+    platform.async_register_entity_service() during setup."""
+    entry = MagicMock(entry_id="test_entry")
+    config_entry_data = MagicMock(users={})
+    config_entry_data.api.users = {}
+    config_entry_data.api.device_id = "test-device-id"
+
+    hass = MagicMock()
+    hass.data = {DOMAIN: {entry.entry_id: config_entry_data}}
+
+    platform = MagicMock()
+    registered_service_names: set[str] = set()
+    platform.async_register_entity_service.side_effect = (
+        lambda name, *_args, **_kwargs: registered_service_names.add(name)
+    )
+
+    with patch(
+        "custom_components.eight_sleep.sensor.async_get_current_platform",
+        return_value=platform,
+    ):
+        await async_setup_entry(hass, entry, MagicMock())
+
+    declared = _declared_service_names()
+    missing = declared - registered_service_names
+    assert not missing, (
+        f"Declared in services.yaml but never registered: {sorted(missing)}"
+    )


### PR DESCRIPTION
## Summary

Closes #101. Spook (a separate HA integration that scans automations/scripts for calls to nonexistent services) flags an "unknown action" for this integration, and the same error surfaces from Home Assistant core itself when the service is actually called ("Unable to find service").

Root cause: `services.yaml` declared 14 entity services, but `async_setup_entry()` in `sensor.py` only called `platform.async_register_entity_service()` for 12 of them. `set_routine_alarm` and `set_routine_bedtime` were declared (so HA's UI/docs happily offer them as callable) and their handler methods (`async_set_routine_alarm`, `async_set_routine_bedtime`) already exist on the entity — but nothing ever wired the service name to the handler. Calling either from an automation raised "Unable to find service".

Fix: register `set_routine_alarm`, matching the existing `set_bed_side`/`prime_pod` style (literal string name, since it post-dates the `SERVICE_*` constants in `const.py`).

**`set_routine_bedtime` is deliberately left unregistered and removed from `services.yaml`** (per [review](https://github.com/lukas-clarke/eight_sleep/pull/152#discussion_r3876106802)): its handler, `EightUser.set_routine_bedtime()`, is a no-op that only logs a warning -- Eight Sleep's API no longer supports bedtime routines. Registering it would have silenced the original "Unable to find service" error while making automations that call it appear to succeed without doing anything. Implementing it against whatever replaced the routines API isn't something I can validate, so leaving it unregistered (an explicit, visible failure) is safer than a silent no-op.

One deliberate choice on `set_routine_alarm`: the fields are registered as plain strings (`vol.All(vol.Coerce(str))`), not `cv.time`, even though `services.yaml`'s selector is `time:`. `set_alarm_time()` in pyEight sends `alarm_time` straight through as a JSON body field to the Eight Sleep API; `cv.time` would hand it a `datetime.time` object, which aiohttp's default JSON encoder can't serialize. (Worth a look separately: `set_one_off_alarm`'s existing registration *does* use `cv.time` for its `time` field feeding the same kind of JSON body in `set_one_off_alarm()` -- I didn't touch it since it's unrelated to #101, but it looks like the same class of bug.)

## Testing

No existing test harness covers the `sensor.py` service-registration layer (only the vendored `pyEight` library has tests), so I added one: `tests/test_sensor_services.py` calls the real `async_setup_entry()` with a mocked platform/hass and asserts every service name in `services.yaml` was actually registered.

- Reproduces the original bug: fails against unmodified `main` (`Declared in services.yaml but never registered: ['set_routine_alarm', 'set_routine_bedtime']`).
- Two more tests confirm `set_routine_bedtime` stays out of both `services.yaml` and the registered set -- both fail against the first version of this PR (before the review) and pass now.
- Mutation-tested throughout.
- Full suite (`pyEight`'s own tests + the new tests): 88/92 passed. The 4 failures (`test_auth.py::test_start_successful`, `test_eight.py::test_fetch_device_list_successful`, `test_speaker.py::test_fetch_device_list_sets_has_speaker_from_audio_feature`, `test_speaker.py::test_probe_speaker_availability_request_error`) reproduce identically on unmodified `main` (confirmed via `git stash`) -- pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
