### PR TITLE
Add hub firmware/online binary sensors; make priming/water proper booleans

### DIFF
--- a/custom_components/eight_sleep/binary_sensor.py
+++ b/custom_components/eight_sleep/binary_sensor.py
@@ -31,6 +31,38 @@ SNORE_MITIGATION_DESCRIPTION = BinarySensorEntityDescription(
     icon="mdi:account-alert",
 )
 
+# Device-level (hub) status booleans, sourced from the device doc.
+IS_PRIMING_DESCRIPTION = BinarySensorEntityDescription(
+    key="is_priming",
+    name="Is Priming",
+    device_class=BinarySensorDeviceClass.RUNNING,
+)
+
+NEED_PRIMING_DESCRIPTION = BinarySensorEntityDescription(
+    key="need_priming",
+    name="Need Priming",
+    device_class=BinarySensorDeviceClass.PROBLEM,
+    icon="mdi:water-alert",
+)
+
+HAS_WATER_DESCRIPTION = BinarySensorEntityDescription(
+    key="has_water",
+    name="Has Water",
+    icon="mdi:water",
+)
+
+FIRMWARE_UPDATING_DESCRIPTION = BinarySensorEntityDescription(
+    key="firmware_updating",
+    name="Firmware Updating",
+    device_class=BinarySensorDeviceClass.UPDATE,
+)
+
+ONLINE_DESCRIPTION = BinarySensorEntityDescription(
+    key="online",
+    name="Online",
+    device_class=BinarySensorDeviceClass.CONNECTIVITY,
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -60,6 +92,19 @@ async def async_setup_entry(
             SNORE_MITIGATION_DESCRIPTION,
             lambda: base_user.in_snore_mitigation,
             base_entity=True))
+
+    # Device-level (hub) status bools — driven by the device coordinator so HA
+    # sees on/off transitions (priming / water / firmware-updating / online).
+    device_coordinator = config_entry_data.device_coordinator
+    for description, getter in (
+        (IS_PRIMING_DESCRIPTION, lambda: eight.is_priming),
+        (NEED_PRIMING_DESCRIPTION, lambda: eight.need_priming),
+        (HAS_WATER_DESCRIPTION, lambda: eight.has_water),
+        (FIRMWARE_UPDATING_DESCRIPTION, lambda: eight.firmware_updating),
+        (ONLINE_DESCRIPTION, lambda: eight.online),
+    ):
+        entities.append(EightBinaryEntity(
+            entry, device_coordinator, eight, None, description, getter))
 
     async_add_entities(entities)
 

--- a/custom_components/eight_sleep/pyEight/eight.py
+++ b/custom_components/eight_sleep/pyEight/eight.py
@@ -144,19 +144,45 @@ class EightSleep:
 
     @property
     def need_priming(self) -> bool:
-        return self.device_data["needsPriming"]
+        return bool(self.device_data.get("needsPriming", False))
 
     @property
     def is_priming(self) -> bool:
-        return self.device_data["priming"]
+        return bool(self.device_data.get("priming", False))
 
     @property
     def has_water(self) -> bool:
-        return self.device_data["hasWater"]
+        return bool(self.device_data.get("hasWater", False))
 
     @property
     def last_prime(self):
         return self.convert_string_to_datetime(self.device_data["lastPrime"])
+
+    @property
+    def firmware_version(self) -> str | None:
+        """Installed firmware short version, e.g. '444c5a9'."""
+        return self.device_data.get("firmwareVersion")
+
+    @property
+    def firmware_commit(self) -> str | None:
+        """Installed firmware full commit hash."""
+        return self.device_data.get("firmwareCommit")
+
+    @property
+    def firmware_updating(self) -> bool:
+        """True while an OTA is in progress (the device self-reboots to apply)."""
+        return bool(self.device_data.get("firmwareUpdating", False))
+
+    @property
+    def online(self) -> bool:
+        """Cloud-reported device online flag."""
+        return bool(self.device_data.get("online", False))
+
+    @property
+    def last_heard(self):
+        """Timestamp the cloud last heard from the device (liveness)."""
+        last_heard = self.device_data.get("lastHeard")
+        return self.convert_string_to_datetime(last_heard) if last_heard else None
 
     @property
     def is_pod(self) -> bool:

--- a/custom_components/eight_sleep/sensor.py
+++ b/custom_components/eight_sleep/sensor.py
@@ -19,7 +19,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     UnitOfTemperature,
-    CONF_BINARY_SENSORS,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
@@ -98,12 +97,13 @@ EIGHT_USER_SENSORS = [
 ]
 
 EIGHT_HEAT_SENSORS = ["bed_state"]
+# Priming / water / firmware-updating / online are now proper binary_sensors
+# (see binary_sensor.py) so HA reads their on/off transitions correctly.
 EIGHT_ROOM_SENSORS = [
     "room_temperature",
-    "need_priming",
-    "is_priming",
-    "has_water",
     "last_prime",
+    "last_heard",
+    "firmware_version",
 ]
 
 VALID_TARGET_HEAT = vol.All(vol.Coerce(int), vol.Clamp(min=-100, max=100))
@@ -492,11 +492,10 @@ class EightRoomSensor(EightSleepBaseEntity, SensorEntity):
             self._attr_device_class = SensorDeviceClass.TEMPERATURE
             self._attr_state_class = SensorStateClass.MEASUREMENT
             self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
-        elif self._sensor == "last_prime":
+        elif self._sensor in ("last_prime", "last_heard"):
             self._attr_device_class = SensorDeviceClass.TIMESTAMP
-        else:
-            self._attr_state_class = CONF_BINARY_SENSORS
-            self._attr_device_class = CONF_BINARY_SENSORS
+        elif self._sensor == "firmware_version":
+            self._attr_icon = "mdi:chip"
 
     @property
     def native_value(self) -> int | float | None:


### PR DESCRIPTION
## What

Adds hub-level status entities and moves boolean priming and water values from `sensor` to `binary_sensor`.

New entities with no upstream equivalent:

- `binary_sensor` **firmware updating**: true while the Pod applies a firmware update
- `binary_sensor` **online**: whether the hub is reachable/reporting
- `sensor` **firmware version** and **last heard**: sourced from the device doc

The `is_priming`, `need_priming`, and `has_water` entities now use the `binary_sensor` domain.

## Why

These are boolean device states, so `binary_sensor` is the correct Home Assistant domain. That gives them on/off states, `device_class` semantics, correct UI rendering, and direct use in `state:` / `numeric_state:` conditions.

As `sensor` entities, the automation engine treats their values as opaque strings, requiring comparisons such as `states('sensor.x') == 'True'`.

One practical use case is safely power-cycling the Pod on a schedule through a smart plug:

- `firmware_updating` prevents power from being cut during an OTA update, which risks bricking the hub.
- `is_priming` prevents a priming cycle from being interrupted.
- `online` confirms that the hub returned after the power cycle.

## ⚠️ Breaking change

The priming/water entities change domain, so their entity_ids change:

| Before | After |
|---|---|
| `sensor.<pod>_is_priming` | `binary_sensor.<pod>_hub_is_priming` |
| `sensor.<pod>_need_priming` | `binary_sensor.<pod>_hub_need_priming` |
| `sensor.<pod>_has_water` | `binary_sensor.<pod>_hub_has_water` |

Anyone referencing the old `sensor.*` entities in automations or dashboards will need to update them. (`firmware_updating` / `online` are new — no migration.)

## Reliability

The priming, water, and firmware getters in `pyEight` now use `.get(key, False)` and `bool(...)`. If a key is missing from the device doc, the getter returns `False` instead of raising `KeyError`.

## Testing

Tested on HA Core 2026.9.1 against a live Pod. The integration loads cleanly, and the new binary sensors report live state:

- `online` = on
- `has_water` = on
- priming = off
- `firmware_updating` = off
